### PR TITLE
Wave 5: Stretch goals — run stats, achievements, multi-floor, seeded runs

### DIFF
--- a/Engine/CommandParser.cs
+++ b/Engine/CommandParser.cs
@@ -17,6 +17,7 @@ public enum CommandType
     Save,
     Load,
     ListSaves,
+    Descend,
     Unknown
 }
 
@@ -61,6 +62,7 @@ public static class CommandParser
             "save" => new ParsedCommand { Type = CommandType.Save, Argument = argument },
             "load" => new ParsedCommand { Type = CommandType.Load, Argument = argument },
             "list" or "saves" => new ParsedCommand { Type = CommandType.ListSaves },
+            "descend" or "down" => new ParsedCommand { Type = CommandType.Descend },
             _ => new ParsedCommand { Type = CommandType.Unknown }
         };
     }

--- a/Engine/DungeonGenerator.cs
+++ b/Engine/DungeonGenerator.cs
@@ -24,7 +24,7 @@ public class DungeonGenerator
         _rng = seed.HasValue ? new Random(seed.Value) : new Random();
     }
 
-    public (Room startRoom, Room exitRoom) Generate(int width = 5, int height = 4, int playerLevel = 1)
+    public (Room startRoom, Room exitRoom) Generate(int width = 5, int height = 4, int playerLevel = 1, float floorMultiplier = 1.0f)
     {
         // Create grid of rooms
         var grid = new Room[height, width];
@@ -71,7 +71,7 @@ public class DungeonGenerator
         exitRoom.Description = "A grand chamber with ornate pillars and a massive stone door leading to freedom.";
 
         // Place boss in exit room
-        exitRoom.Enemy = EnemyFactory.CreateScaled("dungeonboss", playerLevel);
+        exitRoom.Enemy = EnemyFactory.CreateScaled("dungeonboss", playerLevel, floorMultiplier);
 
         // Place enemies in ~60% of non-start, non-exit rooms
         var enemyTypes = new[] { "goblin", "skeleton", "troll", "darkknight" };
@@ -85,7 +85,7 @@ public class DungeonGenerator
                 if (_rng.NextDouble() < 0.6)
                 {
                     var enemyType = enemyTypes[_rng.Next(enemyTypes.Length)];
-                    room.Enemy = EnemyFactory.CreateScaled(enemyType, playerLevel);
+                    room.Enemy = EnemyFactory.CreateScaled(enemyType, playerLevel, floorMultiplier);
                 }
             }
         }

--- a/Engine/EnemyFactory.cs
+++ b/Engine/EnemyFactory.cs
@@ -49,9 +49,9 @@ public static class EnemyFactory
         return new DungeonBoss(_enemyConfig?.GetValueOrDefault("DungeonBoss"), _itemConfig);
     }
 
-    public static Enemy CreateScaled(string enemyType, int playerLevel)
+    public static Enemy CreateScaled(string enemyType, int playerLevel, float floorMultiplier = 1.0f)
     {
-        var scalar = 1.0f + (playerLevel - 1) * 0.12f;
+        var scalar = (1.0f + (playerLevel - 1) * 0.12f) * floorMultiplier;
         
         var baseStats = enemyType.ToLower() switch
         {

--- a/Program.cs
+++ b/Program.cs
@@ -7,11 +7,22 @@ display.ShowTitle();
 
 var name = display.ReadPlayerName();
 
+// Seed selection
+display.ShowMessage("Enter a seed for reproducible runs (or press Enter for random):");
+display.ShowCommandPrompt();
+var seedInput = Console.ReadLine()?.Trim() ?? "";
+int? seed = int.TryParse(seedInput, out var parsedSeed) ? parsedSeed : null;
+var actualSeed = seed ?? new Random().Next(100000, 999999);
+if (seed == null)
+    display.ShowMessage($"Random seed: {actualSeed} (share this to replay the same run)");
+else
+    display.ShowMessage($"Using seed: {actualSeed}");
+
 var player = new Player { Name = name };
-var generator = new DungeonGenerator();
+var generator = new DungeonGenerator(actualSeed);
 var (startRoom, _) = generator.Generate();
 
 var inputReader = new ConsoleInputReader();
 var combat = new CombatEngine(display, inputReader);
-var gameLoop = new GameLoop(display, combat, inputReader);
+var gameLoop = new GameLoop(display, combat, inputReader, seed: actualSeed);
 gameLoop.Run(player, startRoom);

--- a/Systems/AchievementSystem.cs
+++ b/Systems/AchievementSystem.cs
@@ -1,0 +1,96 @@
+namespace Dungnz.Systems;
+
+using System.Text.Json;
+using Dungnz.Models;
+
+public class Achievement
+{
+    public string Name { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public Func<RunStats, Player, bool> Condition { get; init; } = (_, _) => false;
+    public bool Unlocked { get; set; }
+}
+
+public class AchievementSystem
+{
+    private static readonly string HistoryPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Dungnz", "achievements.json");
+
+    public List<Achievement> Achievements { get; } = new()
+    {
+        new Achievement
+        {
+            Name = "Glass Cannon",
+            Description = "Win a run with HP below 10.",
+            Condition = (_, player) => player.HP < 10
+        },
+        new Achievement
+        {
+            Name = "Untouchable",
+            Description = "Win a run without taking any damage.",
+            Condition = (stats, _) => stats.DamageTaken == 0
+        },
+        new Achievement
+        {
+            Name = "Hoarder",
+            Description = "Collect 500+ gold in a single run.",
+            Condition = (stats, _) => stats.GoldCollected >= 500
+        },
+        new Achievement
+        {
+            Name = "Elite Hunter",
+            Description = "Defeat 10+ enemies in a single run.",
+            Condition = (stats, _) => stats.EnemiesDefeated >= 10
+        },
+        new Achievement
+        {
+            Name = "Speed Runner",
+            Description = "Win a run in under 100 turns.",
+            Condition = (stats, _) => stats.TurnsTaken < 100
+        }
+    };
+
+    public List<Achievement> Evaluate(RunStats stats, Player player, bool won)
+    {
+        if (!won) return new List<Achievement>();
+
+        var newlyUnlocked = new List<Achievement>();
+        var savedNames = LoadUnlocked();
+
+        foreach (var a in Achievements)
+        {
+            a.Unlocked = savedNames.Contains(a.Name);
+            if (!a.Unlocked && a.Condition(stats, player))
+            {
+                a.Unlocked = true;
+                savedNames.Add(a.Name);
+                newlyUnlocked.Add(a);
+            }
+        }
+
+        SaveUnlocked(savedNames);
+        return newlyUnlocked;
+    }
+
+    private static HashSet<string> LoadUnlocked()
+    {
+        try
+        {
+            if (File.Exists(HistoryPath))
+                return JsonSerializer.Deserialize<HashSet<string>>(File.ReadAllText(HistoryPath)) ?? new();
+        }
+        catch { }
+        return new HashSet<string>();
+    }
+
+    private static void SaveUnlocked(HashSet<string> names)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(HistoryPath)!);
+            File.WriteAllText(HistoryPath, JsonSerializer.Serialize(names, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch { }
+    }
+}

--- a/Systems/RunStats.cs
+++ b/Systems/RunStats.cs
@@ -1,0 +1,67 @@
+namespace Dungnz.Systems;
+
+using System.Text.Json;
+
+public class RunStats
+{
+    public int TurnsTaken { get; set; }
+    public int EnemiesDefeated { get; set; }
+    public int DamageDealt { get; set; }
+    public int DamageTaken { get; set; }
+    public int GoldCollected { get; set; }
+    public int ItemsFound { get; set; }
+    public int FinalLevel { get; set; }
+    public TimeSpan TimeElapsed { get; set; }
+
+    public void Display(Action<string> output)
+    {
+        output("=== RUN STATISTICS ===");
+        output($"Turns Taken:      {TurnsTaken}");
+        output($"Enemies Defeated: {EnemiesDefeated}");
+        output($"Damage Dealt:     {DamageDealt}");
+        output($"Damage Taken:     {DamageTaken}");
+        output($"Gold Collected:   {GoldCollected}");
+        output($"Items Found:      {ItemsFound}");
+        output($"Final Level:      {FinalLevel}");
+        output($"Time Elapsed:     {(int)TimeElapsed.TotalMinutes}m {TimeElapsed.Seconds}s");
+    }
+
+    public static void AppendToHistory(RunStats stats, bool won)
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Dungnz");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "stats-history.json");
+
+            var entries = new List<object>();
+            if (File.Exists(path))
+            {
+                var existing = JsonSerializer.Deserialize<List<JsonElement>>(File.ReadAllText(path));
+                if (existing != null) entries.AddRange(existing.Cast<object>());
+            }
+
+            entries.Add(new
+            {
+                Date = DateTime.UtcNow,
+                Won = won,
+                stats.TurnsTaken,
+                stats.EnemiesDefeated,
+                stats.DamageDealt,
+                stats.DamageTaken,
+                stats.GoldCollected,
+                stats.ItemsFound,
+                stats.FinalLevel,
+                TimeElapsedSeconds = (int)stats.TimeElapsed.TotalSeconds
+            });
+
+            File.WriteAllText(path, JsonSerializer.Serialize(entries, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch
+        {
+            // Non-critical — don't crash the game if history can't be written
+        }
+    }
+}


### PR DESCRIPTION
Implements all 4 stretch goal issues for v2:

- **#22 Multi-floor dungeons** — 5 floors, DESCEND command, +50% enemy scaling per floor, true ending on floor 5
- **#23 Achievements** — 5 achievements (Glass Cannon, Untouchable, Hoarder, Elite Hunter, Speed Runner), persisted to AppData
- **#24 Seeded runs** — seed prompt at start, displayed on win/lose screen
- **#25 Run statistics** — turns, enemies defeated, items found, gold collected, damage; displayed on game end + persisted to JSON history

All issues: #22 #23 #24 #25