### PR TITLE
Bugfix: GameLoop, DungeonGenerator, Crafting fixes (#87 #89 #99 #100 #101 #102 #109)

### DIFF
--- a/Engine/DungeonGenerator.cs
+++ b/Engine/DungeonGenerator.cs
@@ -144,6 +144,7 @@ public class DungeonGenerator
             for (int x = 0; x < width; x++)
             {
                 var room = grid[y, x];
+                if (room == startRoom || room == exitRoom) continue;
                 if (_rng.NextDouble() < 0.3)
                 {
                     room.Items.Add(CreateRandomItem());

--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -26,6 +26,7 @@ public class GameLoop
     private DateTime _runStart;
     private readonly AchievementSystem _achievements = new();
     private readonly EquipmentManager _equipment;
+    private readonly InventoryManager _inventoryManager;
     private int _currentFloor = 1;
 
     /// <summary>
@@ -58,6 +59,7 @@ public class GameLoop
         _seed = seed;
         _difficulty = difficulty ?? DifficultySettings.For(Difficulty.Normal);
         _equipment = new EquipmentManager(display);
+        _inventoryManager = new InventoryManager(display);
     }
 
     /// <summary>
@@ -236,7 +238,13 @@ public class GameLoop
             _display.ShowMessage($"⚠ You trigger {hazardName} and take {dmg} damage! HP: {_player.HP}/{_player.MaxHP}");
             if (_player.HP <= 0)
             {
-                _display.ShowMessage("You died from a trap!");
+                _display.ShowMessage("You died from a trap! Game over.");
+                _display.ShowMessage($"Difficulty: {GetDifficultyName()}");
+                if (_seed.HasValue) _display.ShowMessage($"Run seed: {_seed.Value}");
+                _stats.FinalLevel = _player.Level;
+                _stats.TimeElapsed = DateTime.UtcNow - _runStart;
+                _stats.Display(_display.ShowMessage);
+                RunStats.AppendToHistory(_stats, won: false);
                 PrestigeSystem.RecordRun(won: false);
                 return;
             }
@@ -372,7 +380,12 @@ public class GameLoop
         }
 
         _currentRoom.Items.Remove(item);
-        _player.Inventory.Add(item);
+        if (!_inventoryManager.TryAddItem(_player, item))
+        {
+            _currentRoom.Items.Add(item);
+            _display.ShowMessage("Your inventory is full!");
+            return;
+        }
         _display.ShowMessage($"You take the {item.Name}.");
         _events?.RaiseItemPicked(_player, item, _currentRoom);
         _stats.ItemsFound++;
@@ -413,6 +426,20 @@ public class GameLoop
                     var healedAmount = _player.HP - oldHP;
                     _player.Inventory.Remove(item);
                     _display.ShowMessage($"You use {item.Name} and restore {healedAmount} HP. Current HP: {_player.HP}/{_player.MaxHP}");
+                }
+                else if (item.MaxManaBonus > 0)
+                {
+                    var oldMana = _player.Mana;
+                    _player.RestoreMana(item.MaxManaBonus);
+                    var restoredMana = _player.Mana - oldMana;
+                    _player.Inventory.Remove(item);
+                    _display.ShowMessage($"You use {item.Name} and restore {restoredMana} mana. Mana: {_player.Mana}/{_player.MaxMana}");
+                }
+                else if (item.AttackBonus > 0)
+                {
+                    _player.ModifyAttack(item.AttackBonus);
+                    _player.Inventory.Remove(item);
+                    _display.ShowMessage($"You use {item.Name}. Attack permanently +{item.AttackBonus}. Attack: {_player.Attack}");
                 }
                 else
                 {
@@ -475,6 +502,27 @@ public class GameLoop
         if (!_currentRoom.IsExit || _currentRoom.Enemy != null)
         {
             _display.ShowError("You can only descend at a cleared exit room.");
+            return;
+        }
+
+        const int finalFloor = 5;
+        if (_currentFloor >= finalFloor)
+        {
+            _display.ShowMessage("You escaped the dungeon! You win!");
+            _display.ShowMessage($"Difficulty: {GetDifficultyName()}");
+            if (_seed.HasValue) _display.ShowMessage($"Run seed: {_seed.Value}");
+            _stats.FinalLevel = _player.Level;
+            _stats.TimeElapsed = DateTime.UtcNow - _runStart;
+            _stats.Display(_display.ShowMessage);
+            RunStats.AppendToHistory(_stats, won: true);
+            PrestigeSystem.RecordRun(won: true);
+            var unlocked = _achievements.Evaluate(_stats, _player, won: true);
+            if (unlocked.Count > 0)
+            {
+                _display.ShowMessage("=== ACHIEVEMENTS UNLOCKED ===");
+                foreach (var a in unlocked)
+                    _display.ShowMessage($"\U0001f3c6 {a.Name} \u2014 {a.Description}");
+            }
             return;
         }
 
@@ -613,6 +661,7 @@ public class GameLoop
             {
                 _player.SpendGold(selected.Price);
                 _player.Inventory.Add(selected.Item);
+                merchant.Stock.RemoveAt(choice - 1);
                 _display.ShowMessage($"You bought {selected.Item.Name} for {selected.Price}g. Gold remaining: {_player.Gold}g");
             }
         }

--- a/Models/Merchant.cs
+++ b/Models/Merchant.cs
@@ -16,7 +16,7 @@ public class Merchant
         var items = new List<MerchantItem>
         {
             new() { Item = new Item { Name="Health Potion", Type=ItemType.Consumable, HealAmount=30, Description="Restores 30 HP." }, Price = 25 },
-            new() { Item = new Item { Name="Mana Potion", Type=ItemType.Consumable, HealAmount=0, Description="Restores 20 mana." }, Price = 20 },
+            new() { Item = new Item { Name="Mana Potion", Type=ItemType.Consumable, HealAmount=0, MaxManaBonus=20, Description="Restores 20 mana." }, Price = 20 },
             new() { Item = new Item { Name="Iron Sword", Type=ItemType.Weapon, AttackBonus=4, IsEquippable=true, Description="A sturdy iron blade." }, Price = 50 },
             new() { Item = new Item { Name="Iron Shield", Type=ItemType.Armor, DefenseBonus=4, IsEquippable=true, Description="A basic shield." }, Price = 45 },
             new() { Item = new Item { Name="Elixir of Strength", Type=ItemType.Consumable, HealAmount=0, Description="Permanently +2 Attack.", AttackBonus=2 }, Price = 80 },

--- a/Systems/CraftingSystem.cs
+++ b/Systems/CraftingSystem.cs
@@ -27,7 +27,7 @@ public class CraftingSystem
         },
         new CraftingRecipe {
             Name = "Reinforced Armor",
-            Ingredients = new() { ("Iron Shield", 1) },
+            Ingredients = new() { ("Leather Armor", 1) },
             GoldCost = 25,
             Result = new Item { Name = "Reinforced Armor", Type = ItemType.Armor, DefenseBonus = 8, IsEquippable = true, Description = "Upgraded protection." }
         },


### PR DESCRIPTION
## Summary

Fixes 7 gameplay bugs across the game loop, dungeon generator, crafting system, and merchant.

### Bug #102 — Trap death doesn't end game loop
Hazard damage killing the player now triggers the full game-over path (stats display, history recording, prestige) matching the combat death path.

### Bug #109 — DESCEND on final floor bypasses win and generates floor 6  
`HandleDescend` now checks the win condition before incrementing `_currentFloor`. Typing DESCEND on floor 5 correctly triggers the win sequence instead of generating a floor 6.

### Bug #87 — Mana Potion and Elixir of Strength are unusable
- Mana Potion: given `MaxManaBonus=20`; `HandleUse` now has a `MaxManaBonus > 0` branch that calls `RestoreMana`
- Elixir of Strength: `HandleUse` now has an `AttackBonus > 0` branch that calls `ModifyAttack`

### Bug #89 — Shop items never removed after purchase
After a successful purchase, `merchant.Stock.RemoveAt(choice - 1)` removes the item from stock, preventing infinite buying.

### Bug #99 — Reinforced Armor recipe requires 'Iron Shield' (never generated)
Changed ingredient from `"Iron Shield"` to `"Leather Armor"` which is obtainable from dungeon drops.

### Bug #100 — InventoryManager not wired into GameLoop
`HandleTake` now calls `_inventoryManager.TryAddItem(player, item)` instead of `player.Inventory.Add`. Shows 'Your inventory is full!' if rejected. `_inventoryManager` is instantiated in the constructor.

### Bug #101 — Items placed in start/exit rooms
The item placement loop in `DungeonGenerator.Generate` now skips `startRoom` and `exitRoom`, matching the existing pattern for enemy and shrine placement.

## Files Changed
- `Engine/GameLoop.cs` — Bugs #87, #89, #100, #102, #109
- `Engine/DungeonGenerator.cs` — Bug #101  
- `Models/Merchant.cs` — Bug #87
- `Systems/CraftingSystem.cs` — Bug #99

## Tests
All 228 existing tests pass. Zero new failures.