### PR TITLE
Narration Wave 2: Item flavor descriptions (#126)

### DIFF
--- a/Data/item-stats.json
+++ b/Data/item-stats.json
@@ -1,14 +1,14 @@
 {
   "Items": [
-    {"Name": "Health Potion", "Type": "Consumable", "HealAmount": 20, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "Restores 20 HP"},
-    {"Name": "Large Health Potion", "Type": "Consumable", "HealAmount": 50, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "Restores 50 HP"},
-    {"Name": "Iron Sword", "Type": "Weapon", "HealAmount": 0, "AttackBonus": 5, "DefenseBonus": 0, "StatModifier": 0, "Description": "A sturdy iron blade"},
-    {"Name": "Leather Armor", "Type": "Armor", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 3, "StatModifier": 0, "Description": "Basic leather protection"},
-    {"Name": "Rusty Sword", "Type": "Weapon", "HealAmount": 0, "AttackBonus": 3, "DefenseBonus": 0, "StatModifier": 0, "Description": "A corroded blade."},
-    {"Name": "Bone Fragment", "Type": "Consumable", "HealAmount": 5, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "Shards from the dead."},
-    {"Name": "Troll Hide", "Type": "Armor", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 4, "StatModifier": 0, "Description": "Thick, resilient leather."},
-    {"Name": "Dark Blade", "Type": "Weapon", "HealAmount": 0, "AttackBonus": 5, "DefenseBonus": 0, "StatModifier": 0, "Description": "A blade forged in shadow."},
-    {"Name": "Knight's Armor", "Type": "Armor", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 6, "StatModifier": 0, "Description": "Heavy plated armor."},
-    {"Name": "Boss Key", "Type": "Consumable", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "Proof of your victory."}
+    {"Name": "Health Potion", "Type": "Consumable", "HealAmount": 20, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "A murky red liquid in a stoppered vial. Smells terrible. Works anyway."},
+    {"Name": "Large Health Potion", "Type": "Consumable", "HealAmount": 50, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "A generous dose of the murky healing brew. Double the smell, double the effect."},
+    {"Name": "Iron Sword", "Type": "Weapon", "HealAmount": 0, "AttackBonus": 5, "DefenseBonus": 0, "StatModifier": 0, "Description": "A battered blade, nicked from hard use. It has drawn blood before and will draw it again."},
+    {"Name": "Leather Armor", "Type": "Armor", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 3, "StatModifier": 0, "Description": "Cured hide stitched with coarse thread. Won't stop a greatsword, but it's better than nothing."},
+    {"Name": "Rusty Sword", "Type": "Weapon", "HealAmount": 0, "AttackBonus": 3, "DefenseBonus": 0, "StatModifier": 0, "Description": "A pitted blade eaten through by rust. It still has an edge, after a fashion."},
+    {"Name": "Bone Fragment", "Type": "Consumable", "HealAmount": 5, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "Shards gnawed from something that once walked these halls. A grim remedy, but a remedy nonetheless."},
+    {"Name": "Troll Hide", "Type": "Armor", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 4, "StatModifier": 0, "Description": "Thick, warty hide stripped from a troll. It stinks, but blades glance off it admirably."},
+    {"Name": "Dark Blade", "Type": "Weapon", "HealAmount": 0, "AttackBonus": 5, "DefenseBonus": 0, "StatModifier": 0, "Description": "Forged in shadow and quenched in something cold. The metal drinks in light and gives nothing back."},
+    {"Name": "Knight's Armor", "Type": "Armor", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 6, "StatModifier": 0, "Description": "Heavy plate bearing the dents of many battles. Whoever wore this last did not walk out. You might."},
+    {"Name": "Boss Key", "Type": "Consumable", "HealAmount": 0, "AttackBonus": 0, "DefenseBonus": 0, "StatModifier": 0, "Description": "Cold iron, slick with something you'd rather not examine. It fits the lock ahead."}
   ]
 }

--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -419,6 +419,8 @@ public class GameLoop
         switch (item.Type)
         {
             case ItemType.Consumable:
+                if (!string.IsNullOrEmpty(item.Description))
+                    _display.ShowMessage(item.Description);
                 if (item.HealAmount > 0)
                 {
                     var oldHP = _player.HP;

--- a/Models/Merchant.cs
+++ b/Models/Merchant.cs
@@ -15,11 +15,11 @@ public class Merchant
     {
         var items = new List<MerchantItem>
         {
-            new() { Item = new Item { Name="Health Potion", Type=ItemType.Consumable, HealAmount=30, Description="Restores 30 HP." }, Price = 25 },
-            new() { Item = new Item { Name="Mana Potion", Type=ItemType.Consumable, HealAmount=0, MaxManaBonus=20, Description="Restores 20 mana." }, Price = 20 },
-            new() { Item = new Item { Name="Iron Sword", Type=ItemType.Weapon, AttackBonus=4, IsEquippable=true, Description="A sturdy iron blade." }, Price = 50 },
-            new() { Item = new Item { Name="Iron Shield", Type=ItemType.Armor, DefenseBonus=4, IsEquippable=true, Description="A basic shield." }, Price = 45 },
-            new() { Item = new Item { Name="Elixir of Strength", Type=ItemType.Consumable, HealAmount=0, Description="Permanently +2 Attack.", AttackBonus=2 }, Price = 80 },
+            new() { Item = new Item { Name="Health Potion", Type=ItemType.Consumable, HealAmount=30, Description="A murky red liquid in a stoppered vial. Smells terrible. Works anyway." }, Price = 25 },
+            new() { Item = new Item { Name="Mana Potion", Type=ItemType.Consumable, HealAmount=0, MaxManaBonus=20, Description="Faintly luminescent blue liquid. The arcane energy inside makes your fingers tingle." }, Price = 20 },
+            new() { Item = new Item { Name="Iron Sword", Type=ItemType.Weapon, AttackBonus=4, IsEquippable=true, Description="A battered blade, nicked from hard use. It has drawn blood before and will draw it again." }, Price = 50 },
+            new() { Item = new Item { Name="Iron Shield", Type=ItemType.Armor, DefenseBonus=4, IsEquippable=true, Description="Dented iron, dull as old pewter. It has stopped worse than whatever is down here." }, Price = 45 },
+            new() { Item = new Item { Name="Elixir of Strength", Type=ItemType.Consumable, HealAmount=0, Description="A thick amber fluid. Warriors swear by it. It tastes like iron and lightning.", AttackBonus=2 }, Price = 80 },
         };
         // Pick 3 random items to stock
         var stock = new List<MerchantItem>();

--- a/Systems/CraftingSystem.cs
+++ b/Systems/CraftingSystem.cs
@@ -17,19 +17,19 @@ public class CraftingSystem
             Name = "Health Elixir",
             Ingredients = new() { ("Health Potion", 2) },
             GoldCost = 0,
-            Result = new Item { Name = "Health Elixir", Type = ItemType.Consumable, HealAmount = 75, Description = "Restores 75 HP." }
+            Result = new Item { Name = "Health Elixir", Type = ItemType.Consumable, HealAmount = 75, Description = "Two potions rendered down into something stronger. The colour is wrong, but the effect is not." }
         },
         new CraftingRecipe {
             Name = "Reinforced Sword",
             Ingredients = new() { ("Iron Sword", 1) },
             GoldCost = 30,
-            Result = new Item { Name = "Reinforced Sword", Type = ItemType.Weapon, AttackBonus = 8, IsEquippable = true, Description = "A stronger blade." }
+            Result = new Item { Name = "Reinforced Sword", Type = ItemType.Weapon, AttackBonus = 8, IsEquippable = true, Description = "The iron has been retempered and the edge reground. It bites deeper now." }
         },
         new CraftingRecipe {
             Name = "Reinforced Armor",
             Ingredients = new() { ("Leather Armor", 1) },
             GoldCost = 25,
-            Result = new Item { Name = "Reinforced Armor", Type = ItemType.Armor, DefenseBonus = 8, IsEquippable = true, Description = "Upgraded protection." }
+            Result = new Item { Name = "Reinforced Armor", Type = ItemType.Armor, DefenseBonus = 8, IsEquippable = true, Description = "Extra plates riveted over the weak points. Heavier, but considerably harder to kill through." }
         },
     };
 

--- a/Systems/EquipmentManager.cs
+++ b/Systems/EquipmentManager.cs
@@ -45,6 +45,8 @@ public class EquipmentManager
         {
             player.EquipItem(item);
             _display.ShowMessage($"You equip {item.Name}. Attack: {player.Attack}, Defense: {player.Defense}");
+            if (!string.IsNullOrEmpty(item.Description))
+                _display.ShowMessage(item.Description);
         }
         catch (ArgumentException ex)
         {


### PR DESCRIPTION
Closes #126

## Changes
- **Data/item-stats.json**: All 10 items updated with atmospheric flavor text
- **Models/Merchant.cs**: 5 merchant items updated with atmospheric flavor text
- **Systems/CraftingSystem.cs**: 3 crafted items updated with atmospheric flavor text
- **Engine/GameLoop.cs**: Show `Description` before effect when player USEs a consumable
- **Systems/EquipmentManager.cs**: Show `Description` after stat line when player EQUIPs gear

## Examples
- Health Potion: *"A murky red liquid in a stoppered vial. Smells terrible. Works anyway."*
- Iron Sword: *"A battered blade, nicked from hard use. It has drawn blood before and will draw it again."*
- Knight's Armor: *"Heavy plate bearing the dents of many battles. Whoever wore this last did not walk out. You might."*

All 249 tests pass.