### PR TITLE
Narration Wave 3: Dramatic boss introductions and defeat narration (#118)

### DIFF
--- a/Engine/CombatEngine.cs
+++ b/Engine/CombatEngine.cs
@@ -121,7 +121,15 @@ public class CombatEngine : ICombatEngine
     public CombatResult RunCombat(Player player, Enemy enemy, RunStats? stats = null)
     {
         if (stats != null) _stats = stats;
-        _display.ShowCombat(_narration.Pick(EnemyNarration.GetIntros(enemy.Name), enemy.Name));
+        if (enemy is DungeonBoss)
+        {
+            foreach (var line in BossNarration.GetIntro(enemy.Name))
+                _display.ShowCombat(line);
+        }
+        else
+        {
+            _display.ShowCombat(_narration.Pick(EnemyNarration.GetIntros(enemy.Name), enemy.Name));
+        }
         _turnLog.Clear();
 
         // Ambush: Mimic gets a free first strike before the player can act
@@ -151,7 +159,7 @@ public class CombatEngine : ICombatEngine
             
             if (enemy.HP <= 0)
             {
-                _display.ShowCombat(_narration.Pick(EnemyNarration.GetDeaths(enemy.Name), enemy.Name));
+                ShowDeathNarration(enemy);
                 HandleLootAndXP(player, enemy);
                 return CombatResult.Won;
             }
@@ -198,7 +206,7 @@ public class CombatEngine : ICombatEngine
                 {
                     if (enemy.HP <= 0)
                     {
-                        _display.ShowCombat(_narration.Pick(EnemyNarration.GetDeaths(enemy.Name), enemy.Name));
+                        ShowDeathNarration(enemy);
                         HandleLootAndXP(player, enemy);
                         return CombatResult.Won;
                     }
@@ -214,7 +222,7 @@ public class CombatEngine : ICombatEngine
                 
                 if (enemy.HP <= 0)
                 {
-                    _display.ShowCombat(_narration.Pick(EnemyNarration.GetDeaths(enemy.Name), enemy.Name));
+                    ShowDeathNarration(enemy);
                     HandleLootAndXP(player, enemy);
                     return CombatResult.Won;
                 }
@@ -534,6 +542,14 @@ public class CombatEngine : ICombatEngine
         }
     }
     
+    private void ShowDeathNarration(Enemy enemy)
+    {
+        if (enemy is DungeonBoss)
+            _display.ShowCombat(BossNarration.GetDeath(enemy.Name));
+        else
+            _display.ShowCombat(_narration.Pick(EnemyNarration.GetDeaths(enemy.Name), enemy.Name));
+    }
+
     private bool RollDodge(int defense)
     {
         var dodgeChance = defense / (double)(defense + 20);

--- a/Systems/BossNarration.cs
+++ b/Systems/BossNarration.cs
@@ -1,0 +1,72 @@
+namespace Dungnz.Systems;
+
+/// <summary>
+/// Provides multi-line dramatic introductions and unique death narration for each
+/// boss variant. Intros are returned in order and should be displayed sequentially
+/// as a build-up, not picked at random.
+/// </summary>
+public static class BossNarration
+{
+    private static readonly Dictionary<string, string[]> _intros = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Dungeon Boss"] = new[]
+        {
+            "The ground shakes.",
+            "Something ancient and terrible stirs in the darkness ahead.",
+            "The dungeon boss emerges — this is what you came for."
+        },
+        ["Lich King"] = new[]
+        {
+            "The temperature plummets. Your breath fogs in the frigid air.",
+            "Blue-green flames flicker to life in empty eye sockets as a robed figure rises from a stone throne.",
+            "The Lich King regards you with the cold patience of ten thousand years. 'Another mortal comes to fail.'"
+        },
+        ["Stone Titan"] = new[]
+        {
+            "The floor cracks under something impossibly heavy.",
+            "A shape like a walking mountain resolves from the shadows — granite skin, fists like boulders.",
+            "The Stone Titan turns its featureless face toward you. The ceiling groans under its presence."
+        },
+        ["Shadow Wraith"] = new[]
+        {
+            "The torches go out.",
+            "In the absolute darkness, something breathes — slow, cold, hateful.",
+            "The Shadow Wraith coalesces from the dark itself, a wound in reality shaped like a predator."
+        },
+        ["Vampire Lord"] = new[]
+        {
+            "A figure sits at the far end of the chamber, utterly still.",
+            "It has been waiting for you. Perhaps for centuries. It smiles, and its teeth are wrong.",
+            "'At last,' the Vampire Lord says, 'something worth the evening.'"
+        }
+    };
+
+    private static readonly Dictionary<string, string> _deaths = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Dungeon Boss"] = "The boss collapses with a thunderous crash. The dungeon grows quiet.",
+        ["Lich King"] = "The Lich King releases a terrible shriek as his phylactery shatters. The necromantic energies binding him dissolve into ash. The cold lifts.",
+        ["Stone Titan"] = "The Stone Titan fractures from within, cracks of golden light racing across its body. It shatters into gravel with a sound like a collapsing cliff face.",
+        ["Shadow Wraith"] = "The Shadow Wraith screams a sound that exists only inside your skull. Then — nothing. The torches relight. Whatever it was, it's gone.",
+        ["Vampire Lord"] = "The Vampire Lord staggers, clutching the wound you've dealt. A look of genuine surprise crosses its ancient face. It crumbles to dust before it hits the floor."
+    };
+
+    private static readonly string[] _defaultIntro = { "The ground shakes.", "Something enormous stirs.", "A dungeon boss emerges!" };
+    private static readonly string _defaultDeath = "The boss falls with a thunderous crash.";
+
+    /// <summary>
+    /// Returns the ordered introduction lines for the named boss. Lines should be
+    /// displayed sequentially to build dramatic tension, not selected at random.
+    /// </summary>
+    /// <param name="bossName">The <see cref="Dungnz.Models.Enemy.Name"/> of the boss.</param>
+    /// <returns>An array of narration strings in display order.</returns>
+    public static string[] GetIntro(string bossName) =>
+        _intros.GetValueOrDefault(bossName, _defaultIntro);
+
+    /// <summary>
+    /// Returns the unique death narration line for the named boss.
+    /// </summary>
+    /// <param name="bossName">The <see cref="Dungnz.Models.Enemy.Name"/> of the boss.</param>
+    /// <returns>A single dramatic death narration string.</returns>
+    public static string GetDeath(string bossName) =>
+        _deaths.GetValueOrDefault(bossName, _defaultDeath);
+}


### PR DESCRIPTION
Closes #118

## Changes
- Add `Systems/BossNarration.cs` with sequential multi-line dramatic introductions and unique death narration for all 5 boss types: DungeonBoss, LichKing, StoneTitan, ShadowWraith, VampireBoss.
- Update `CombatEngine.RunCombat` to display boss intro lines sequentially (not randomly) for `DungeonBoss` encounters.
- Add private `ShowDeathNarration` helper that routes to `BossNarration.GetDeath` for bosses and `EnemyNarration.GetDeaths` for all other enemies — all 3 death call sites updated.
- All 249 tests pass, 0 warnings.