### PR TITLE
Narration Wave 4: Dramatic death narration by cause and floor (#124)

### DIFF
--- a/Dungnz.Tests/GameLoopTests.cs
+++ b/Dungnz.Tests/GameLoopTests.cs
@@ -231,7 +231,7 @@ public class GameLoopTests
         var loop = MakeLoop(display, combat.Object, "north");
         loop.Run(player, room);
 
-        display.Messages.Should().Contain(m => m.Contains("Game over") || m.Contains("defeated"));
+        display.Messages.Should().Contain(m => m.Contains("YOU HAVE FALLEN") || m.Contains("defeated"));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #124

## Changes
- Adds `ShowGameOver(string? killedBy, bool byTrap)` with a death banner, floor-specific opening line, cause-of-death line (trap or named killer), and class-specific epitaph
- Wires combat death to `ShowGameOver(killedBy: enemyName)` — enemy name captured before `RunCombat`
- Wires trap/hazard death to `ShowGameOver(byTrap: true)`
- Stats and difficulty line still display after narration (unchanged)
- Fixes a pre-existing duplicate `hazardMsg` declaration from an incomplete Wave 3 merge
- Updates `PlayerDeathInCombat_EndsGameLoop` test to assert on the new banner text

## Test results
All 249 tests pass.