### PR TITLE
Tech debt: CombatEngine — elite cap, dodge cap, shaman cooldown, BattleHardened, ManaFlow

### DIFF
--- a/Dungnz.Tests/CombatEngineTests.cs
+++ b/Dungnz.Tests/CombatEngineTests.cs
@@ -232,9 +232,9 @@ public class CombatEngineTests
     }
 
     [Fact]
-    public void Bug86_BattleHardenedSkill_ReducesIncomingDamageByOne()
+    public void Bug86_BattleHardenedSkill_ReducesIncomingDamageBy5Percent()
     {
-        // Enemy attack=10, player def=0 -> normally 10; BattleHardened -> 9
+        // Enemy attack=10, player def=0 -> normally 10; BattleHardened 5% -> (int)(10*0.95)=9
         var player = new Player { HP = 100, MaxHP = 100, Attack = 1, Defense = 0, Level = 6 };
         player.Skills.TryUnlock(player, Skill.BattleHardened);
         var enemy = new Enemy_Stub(hp: 999, atk: 10, def: 0, xp: 1);


### PR DESCRIPTION
Closes #140, #141, #144, #145, #146

## Changes

- **Fix #140 — Elite stat cap**: Base attack/defense captured at combat start; war cry/resolve buffs now capped at 2x base via `Math.Min`.
- **Fix #141 — Dodge cap**: `RollPlayerDodge` clamps final chance to `0.95f`, preventing permanent-unhittable Rogue builds.
- **Fix #144 — Shaman cooldown**: GoblinShaman can only heal once every 3 enemy turns (`_shamanHealCooldown` field).
- **Fix #145 — BattleHardened**: Implementation changed from flat `-1` to `* 0.95f` to match skill description. Test renamed accordingly.
- **Fix #146 — ManaFlow**: Combat turn mana regen is now 15 (10 base + 5 bonus) when ManaFlow is unlocked.

All 249 tests pass.
