### PR TITLE
Tech debt: GameLoop exit loop, shrine, hazard display, load reset, CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     
     - name: Restore dependencies
       run: dotnet restore


### PR DESCRIPTION
Fixes #137 #138 #139 #142 #143

## Changes
- **Fix 1 (CI #137):** `ci.yml` dotnet-version `9.0.x` → `10.0.x`
- **Fix 2 (BUG-01/02 #138):** Add `_gameOver` field; set to `true` in all win/death paths; `Run()` loop breaks on flag
- **Fix 3 (BUG-03 #139):** Shrine Bless description corrected from '5 rooms' to 'permanently'
- **Fix 4 (BUG-04 #142):** Hazard block: `TakeDamage` moved before message; single `⚠` prefix; no duplicate HP
- **Fix 5 (BUG-07 #143):** `HandleLoad` now resets `_runStart` and `_stats`
- **Fix 6 (Tech debt):** `FinalFloor = 5` extracted as class-level constant

All 249 tests pass.