### PR TITLE
chore: enforce XML doc comments on all public members

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
     
     - name: Build
       run: dotnet build --no-restore
+
+    # CS1591 (missing XML doc) is treated as an error — all public members must have XML comments
+    - name: Enforce XML documentation
+      run: dotnet build Dungnz.csproj --no-restore
     
     - name: Test with coverage
       run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Threshold=70 /p:ThresholdType=line

--- a/Dungnz.csproj
+++ b/Dungnz.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net10.0</TargetFramework>
   <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarningsAsErrors>CS1591</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Models/DungeonVariant.cs
+++ b/Models/DungeonVariant.cs
@@ -1,11 +1,25 @@
 namespace Dungnz.Models;
 
+/// <summary>
+/// Describes the themed name and narrative messages associated with a specific dungeon floor.
+/// </summary>
 public class DungeonVariant
 {
+    /// <summary>Gets the display name of this dungeon variant (e.g. "Goblin Caves").</summary>
     public string Name { get; init; } = "Dungeon";
+
+    /// <summary>Gets the flavour text shown to the player when they descend into this floor.</summary>
     public string EntryMessage { get; init; } = "";
+
+    /// <summary>Gets the flavour text shown to the player when they leave this floor.</summary>
     public string ExitMessage { get; init; } = "";
 
+    /// <summary>
+    /// Returns the <see cref="DungeonVariant"/> appropriate for the given floor number,
+    /// cycling through themed variants for floors 1–5 and falling back to a generic variant beyond that.
+    /// </summary>
+    /// <param name="floor">The 1-based dungeon floor number.</param>
+    /// <returns>A <see cref="DungeonVariant"/> with matching name and entry/exit messages.</returns>
     public static DungeonVariant ForFloor(int floor) => floor switch {
         1 => new() { Name = "Goblin Caves",
             EntryMessage = "You descend into damp, torch-lit goblin caves.",

--- a/Models/Merchant.cs
+++ b/Models/Merchant.cs
@@ -1,16 +1,33 @@
 namespace Dungnz.Models;
 
+/// <summary>Represents a single item in a merchant's stock along with its sale price.</summary>
 public class MerchantItem
 {
+    /// <summary>Gets the item being sold.</summary>
     public Item Item { get; init; } = null!;
+
+    /// <summary>Gets the gold cost the player must pay to purchase this item.</summary>
     public int Price { get; init; }
 }
 
+/// <summary>
+/// Represents a wandering merchant the player can encounter in dungeon rooms.
+/// Holds a randomly selected subset of items that the player can purchase with gold.
+/// </summary>
 public class Merchant
 {
+    /// <summary>Gets the merchant's display name shown in the UI.</summary>
     public string Name { get; init; } = "Wandering Merchant";
+
+    /// <summary>Gets the list of items currently available for purchase from this merchant.</summary>
     public List<MerchantItem> Stock { get; init; } = new();
 
+    /// <summary>
+    /// Creates a new <see cref="Merchant"/> with a randomly chosen subset of three items from
+    /// the predefined pool of available goods.
+    /// </summary>
+    /// <param name="rng">The random number generator used to select the stock.</param>
+    /// <returns>A new <see cref="Merchant"/> instance with three randomly chosen items.</returns>
     public static Merchant CreateRandom(Random rng)
     {
         var items = new List<MerchantItem>

--- a/Models/PlayerClass.cs
+++ b/Models/PlayerClass.cs
@@ -1,33 +1,63 @@
 namespace Dungnz.Models;
 
-public enum PlayerClass { Warrior, Mage, Rogue }
+/// <summary>The available character classes a player can choose at the start of a run.</summary>
+public enum PlayerClass
+{
+    /// <summary>Represents the Warrior class: high HP and defense, slow mana regeneration.</summary>
+    Warrior,
+    /// <summary>Represents the Mage class: high mana and spell power, low HP.</summary>
+    Mage,
+    /// <summary>Represents the Rogue class: balanced stats with an additional dodge bonus.</summary>
+    Rogue
+}
 
+/// <summary>
+/// Holds the full definition of a player class, including its base stat modifiers,
+/// passive trait description, and a static catalogue of all available classes.
+/// </summary>
 public class PlayerClassDefinition
 {
+    /// <summary>Gets the <see cref="PlayerClass"/> enum value this definition corresponds to.</summary>
     public PlayerClass Class { get; init; }
+
+    /// <summary>Gets the human-readable display name of this class.</summary>
     public string Name { get; init; } = "";
+
+    /// <summary>Gets a short description of the class shown during class selection.</summary>
     public string Description { get; init; } = "";
+
+    /// <summary>Gets the flat bonus added to the player's Attack stat when this class is chosen.</summary>
     public int BonusAttack { get; init; }
+
+    /// <summary>Gets the flat bonus added to the player's Defense stat when this class is chosen.</summary>
     public int BonusDefense { get; init; }
+
+    /// <summary>Gets the flat bonus added to the player's maximum HP when this class is chosen.</summary>
     public int BonusMaxHP { get; init; }
+
+    /// <summary>Gets the flat bonus added to the player's maximum mana when this class is chosen.</summary>
     public int BonusMaxMana { get; init; }
 
+    /// <summary>The predefined definition for the Warrior class.</summary>
     public static readonly PlayerClassDefinition Warrior = new() {
         Class = PlayerClass.Warrior, Name = "Warrior",
         Description = "High HP and defense. Slow mana.",
         BonusAttack = 3, BonusDefense = 2, BonusMaxHP = 20, BonusMaxMana = -10
     };
+    /// <summary>The predefined definition for the Mage class.</summary>
     public static readonly PlayerClassDefinition Mage = new() {
         Class = PlayerClass.Mage, Name = "Mage",
         Description = "High mana and powerful spells. Low HP.",
         BonusAttack = 0, BonusDefense = -1, BonusMaxHP = -10, BonusMaxMana = 30
     };
+    /// <summary>The predefined definition for the Rogue class.</summary>
     public static readonly PlayerClassDefinition Rogue = new() {
         Class = PlayerClass.Rogue, Name = "Rogue",
         Description = "Balanced. Extra dodge chance.",
         BonusAttack = 2, BonusDefense = 0, BonusMaxHP = 0, BonusMaxMana = 0
     };
 
+    /// <summary>Gets a short description of the class's passive combat trait.</summary>
     public string TraitDescription => Class switch {
         PlayerClass.Warrior => "Passive: +5% damage when HP < 50%",
         PlayerClass.Mage => "Passive: Spells deal +20% damage",
@@ -35,5 +65,6 @@ public class PlayerClassDefinition
         _ => ""
     };
 
+    /// <summary>Gets a read-only list of all available class definitions.</summary>
     public static IReadOnlyList<PlayerClassDefinition> All => new[] { Warrior, Mage, Rogue };
 }

--- a/Models/PlayerInventory.cs
+++ b/Models/PlayerInventory.cs
@@ -2,6 +2,7 @@ namespace Dungnz.Models;
 
 public partial class Player
 {
+    /// <summary>The maximum number of items the player's inventory can hold.</summary>
     public const int MaxInventorySize = 20;
 
     /// <summary>

--- a/Models/PlayerSkills.cs
+++ b/Models/PlayerSkills.cs
@@ -3,5 +3,6 @@ using Dungnz.Systems;
 
 public partial class Player
 {
+    /// <summary>Gets the player's skill tree, tracking unlocked passive skills and their bonuses.</summary>
     public SkillTree Skills { get; } = new();
 }

--- a/Models/PlayerStats.cs
+++ b/Models/PlayerStats.cs
@@ -7,8 +7,13 @@ public partial class Player
     /// starting stat modifiers, the mana pool size, and passive combat traits.
     /// </summary>
     public PlayerClass Class { get; set; } = PlayerClass.Warrior;
+    /// <summary>
+    /// Gets or sets the additional flat dodge chance granted by the player's class passive
+    /// (e.g. +0.10 for Rogue). Added on top of the defense-based dodge formula during combat.
+    /// </summary>
     public float ClassDodgeBonus { get; set; }
 
+    /// <summary>Gets or sets the player's current hit points. Clamped to [0, <see cref="MaxHP"/>] by combat methods.</summary>
     public int HP { get; set; } = 100;
 
     /// <summary>

--- a/Models/Room.cs
+++ b/Models/Room.cs
@@ -1,10 +1,34 @@
 namespace Dungnz.Models;
 
 /// <summary>Describes the environmental flavour of a dungeon room.</summary>
-public enum RoomType { Standard, Dark, Mossy, Flooded, Scorched, Ancient }
+public enum RoomType
+{
+    /// <summary>Represents a standard, unremarkable dungeon room.</summary>
+    Standard,
+    /// <summary>Represents a darkened room with limited visibility.</summary>
+    Dark,
+    /// <summary>Represents a damp, moss-covered room.</summary>
+    Mossy,
+    /// <summary>Represents a partially flooded room with standing water.</summary>
+    Flooded,
+    /// <summary>Represents a scorched room blackened by fire or magic.</summary>
+    Scorched,
+    /// <summary>Represents an ancient room lined with old stonework and relics.</summary>
+    Ancient
+}
 
 /// <summary>Describes environmental hazards that can damage the player on entry.</summary>
-public enum HazardType { None, Spike, Poison, Fire }
+public enum HazardType
+{
+    /// <summary>Represents the absence of a hazard.</summary>
+    None,
+    /// <summary>Represents a spike trap that deals physical damage on entry.</summary>
+    Spike,
+    /// <summary>Represents a poison cloud that poisons the player on entry.</summary>
+    Poison,
+    /// <summary>Represents a fire hazard that deals burn damage on entry.</summary>
+    Fire
+}
 
 /// <summary>
 /// Represents a single room in the dungeon. Holds navigational connections to adjacent rooms,

--- a/Systems/CraftingSystem.cs
+++ b/Systems/CraftingSystem.cs
@@ -1,16 +1,29 @@
 namespace Dungnz.Systems;
 using Dungnz.Models;
 
+/// <summary>Defines a single crafting recipe, specifying the required ingredients, gold cost, and the item produced.</summary>
 public class CraftingRecipe
 {
+    /// <summary>Gets the display name of this recipe.</summary>
     public string Name { get; init; } = "";
+
+    /// <summary>Gets the list of ingredients required, each as a tuple of item name and required count.</summary>
     public List<(string ItemName, int Count)> Ingredients { get; init; } = new();
+
+    /// <summary>Gets the item that is produced when this recipe is crafted successfully.</summary>
     public Item Result { get; init; } = null!;
+
+    /// <summary>Gets the gold cost that must be paid in addition to providing the required ingredients.</summary>
     public int GoldCost { get; init; }
 }
 
+/// <summary>
+/// Provides the static list of available crafting recipes and the logic for attempting
+/// to craft an item from a player's inventory and gold.
+/// </summary>
 public class CraftingSystem
 {
+    /// <summary>Gets all crafting recipes available in the game.</summary>
     public static readonly List<CraftingRecipe> Recipes = new()
     {
         new CraftingRecipe {
@@ -33,6 +46,16 @@ public class CraftingSystem
         },
     };
 
+    /// <summary>
+    /// Attempts to craft the given recipe for the specified player, consuming ingredients
+    /// and gold from the player's inventory if all requirements are met.
+    /// </summary>
+    /// <param name="player">The player attempting the craft.</param>
+    /// <param name="recipe">The recipe to craft.</param>
+    /// <returns>
+    /// A tuple of <c>success</c> (<see langword="true"/> if crafting succeeded) and a
+    /// <c>message</c> describing the outcome or the reason for failure.
+    /// </returns>
     public static (bool success, string message) TryCraft(Player player, CraftingRecipe recipe)
     {
         // Check inventory capacity

--- a/Systems/Enemies/DarkKnight.cs
+++ b/Systems/Enemies/DarkKnight.cs
@@ -23,6 +23,9 @@ public class DarkKnight : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private DarkKnight() { }
 
+    /// <summary>Initialises a Dark Knight with the given stats and item configuration, or falls back to hard-coded defaults.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration used to source loot drops, or <see langword="null"/> to use inline fallbacks.</param>
     public DarkKnight(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         if (stats != null)

--- a/Systems/Enemies/DungeonBoss.cs
+++ b/Systems/Enemies/DungeonBoss.cs
@@ -47,6 +47,9 @@ public class DungeonBoss : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private DungeonBoss() { }
 
+    /// <summary>Initialises the Dungeon Boss with the given stats and item configuration, or falls back to hard-coded defaults.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration used to source the Boss Key drop, or <see langword="null"/> to use an inline fallback.</param>
     public DungeonBoss(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         if (stats != null)

--- a/Systems/Enemies/Goblin.cs
+++ b/Systems/Enemies/Goblin.cs
@@ -20,6 +20,9 @@ public class Goblin : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private Goblin() { }
 
+    /// <summary>Initialises a Goblin with the given stats and item configuration, or falls back to hard-coded defaults.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration for loot tables; currently unused for this enemy.</param>
     public Goblin(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         if (stats != null)

--- a/Systems/Enemies/GoblinShaman.cs
+++ b/Systems/Enemies/GoblinShaman.cs
@@ -21,6 +21,9 @@ public class GoblinShaman : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private GoblinShaman() { }
 
+    /// <summary>Initialises a Goblin Shaman with the given stats and item configuration, or falls back to hard-coded defaults. Enables poison-on-hit.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration; currently unused for this enemy.</param>
     public GoblinShaman(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         AppliesPoisonOnHit = true;

--- a/Systems/Enemies/Mimic.cs
+++ b/Systems/Enemies/Mimic.cs
@@ -21,6 +21,9 @@ public class Mimic : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private Mimic() { }
 
+    /// <summary>Initialises a Mimic with the given stats and item configuration, or falls back to hard-coded defaults. Enables the ambush mechanic.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration; currently unused for this enemy.</param>
     public Mimic(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         IsAmbush = true; // first-turn surprise: player cannot act

--- a/Systems/Enemies/Skeleton.cs
+++ b/Systems/Enemies/Skeleton.cs
@@ -23,6 +23,9 @@ public class Skeleton : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private Skeleton() { }
 
+    /// <summary>Initialises a Skeleton with the given stats and item configuration, or falls back to hard-coded defaults.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration used to source loot drops, or <see langword="null"/> to use inline fallbacks.</param>
     public Skeleton(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         if (stats != null)

--- a/Systems/Enemies/StoneGolem.cs
+++ b/Systems/Enemies/StoneGolem.cs
@@ -21,6 +21,9 @@ public class StoneGolem : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private StoneGolem() { }
 
+    /// <summary>Initialises a Stone Golem with the given stats and item configuration, or falls back to hard-coded defaults. Enables status-effect immunity.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration; currently unused for this enemy.</param>
     public StoneGolem(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         IsImmuneToEffects = true;

--- a/Systems/Enemies/Troll.cs
+++ b/Systems/Enemies/Troll.cs
@@ -23,6 +23,9 @@ public class Troll : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private Troll() { }
 
+    /// <summary>Initialises a Troll with the given stats and item configuration, or falls back to hard-coded defaults.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration used to source loot drops, or <see langword="null"/> to use inline fallbacks.</param>
     public Troll(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         if (stats != null)

--- a/Systems/Enemies/VampireLord.cs
+++ b/Systems/Enemies/VampireLord.cs
@@ -21,6 +21,9 @@ public class VampireLord : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private VampireLord() { }
 
+    /// <summary>Initialises a Vampire Lord with the given stats and item configuration, or falls back to hard-coded defaults. Sets 50% lifesteal.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration; currently unused for this enemy.</param>
     public VampireLord(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         LifestealPercent = 0.50f; // heals 50% of damage dealt

--- a/Systems/Enemies/Wraith.cs
+++ b/Systems/Enemies/Wraith.cs
@@ -21,6 +21,9 @@ public class Wraith : Enemy
     [System.Text.Json.Serialization.JsonConstructor]
     private Wraith() { }
 
+    /// <summary>Initialises a Wraith with the given stats and item configuration, or falls back to hard-coded defaults. Sets 30% flat dodge chance.</summary>
+    /// <param name="stats">External stats from config, or <see langword="null"/> to use defaults.</param>
+    /// <param name="itemConfig">Item configuration; currently unused for this enemy.</param>
     public Wraith(EnemyStats? stats = null, List<ItemStats>? itemConfig = null)
     {
         FlatDodgeChance = 0.30f; // 30% flat dodge, ignores DEF-based formula

--- a/Systems/EquipmentManager.cs
+++ b/Systems/EquipmentManager.cs
@@ -12,6 +12,9 @@ public class EquipmentManager
 {
     private readonly IDisplayService _display;
 
+    /// <summary>Initialises a new <see cref="EquipmentManager"/> with the given display service.</summary>
+    /// <param name="display">The display service used to output messages and errors to the player.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="display"/> is <see langword="null"/>.</exception>
     public EquipmentManager(IDisplayService display)
     {
         _display = display ?? throw new ArgumentNullException(nameof(display));

--- a/Systems/PrestigeSystem.cs
+++ b/Systems/PrestigeSystem.cs
@@ -1,16 +1,35 @@
 namespace Dungnz.Systems;
 using System.Text.Json;
 
+/// <summary>
+/// Stores the player's cross-run prestige progress, including total wins/runs,
+/// the current prestige level, and the cumulative stat bonuses applied at the start of each run.
+/// </summary>
 public class PrestigeData
 {
+    /// <summary>Gets or sets the player's current prestige level, incremented every three wins.</summary>
     public int PrestigeLevel { get; set; } = 0;
+
+    /// <summary>Gets or sets the total number of dungeon runs the player has won.</summary>
     public int TotalWins { get; set; } = 0;
+
+    /// <summary>Gets or sets the total number of dungeon runs the player has attempted.</summary>
     public int TotalRuns { get; set; } = 0;
+
+    /// <summary>Gets or sets the cumulative flat attack bonus applied to the player at the start of each run.</summary>
     public int BonusStartAttack { get; set; } = 0;
+
+    /// <summary>Gets or sets the cumulative flat defense bonus applied to the player at the start of each run.</summary>
     public int BonusStartDefense { get; set; } = 0;
+
+    /// <summary>Gets or sets the cumulative flat HP bonus applied to the player's maximum HP at the start of each run.</summary>
     public int BonusStartHP { get; set; } = 0;
 }
 
+/// <summary>
+/// Manages loading and saving cross-run prestige data, recording run outcomes, and
+/// returning display strings for the prestige HUD element.
+/// </summary>
 public static class PrestigeSystem
 {
     private static readonly string SavePath = Path.Combine(
@@ -22,6 +41,11 @@ public static class PrestigeSystem
 
     internal static void SetSavePathForTesting(string? path) => _testSavePath = path;
 
+    /// <summary>
+    /// Loads the persisted <see cref="PrestigeData"/> from disk. Returns a default instance
+    /// if the save file does not exist or cannot be read.
+    /// </summary>
+    /// <returns>The loaded <see cref="PrestigeData"/>, or a fresh default instance on failure.</returns>
     public static PrestigeData Load()
     {
         try
@@ -33,6 +57,11 @@ public static class PrestigeSystem
         catch { return new PrestigeData(); }
     }
 
+    /// <summary>
+    /// Persists the given <see cref="PrestigeData"/> to disk as JSON.
+    /// Silently swallows any I/O errors to avoid crashing the game on save failure.
+    /// </summary>
+    /// <param name="data">The prestige data to save.</param>
     public static void Save(PrestigeData data)
     {
         try
@@ -43,6 +72,11 @@ public static class PrestigeSystem
         catch { /* silently fail */ }
     }
 
+    /// <summary>
+    /// Records the outcome of a completed dungeon run, incrementing total run/win counts
+    /// and granting a prestige level (with stat bonuses) every three wins.
+    /// </summary>
+    /// <param name="won"><see langword="true"/> if the player defeated the final boss; <see langword="false"/> otherwise.</param>
     public static void RecordRun(bool won)
     {
         var data = Load();
@@ -62,6 +96,12 @@ public static class PrestigeSystem
         Save(data);
     }
 
+    /// <summary>
+    /// Returns a formatted one-line summary of the player's prestige bonuses for display in the HUD,
+    /// or an empty string if the player has not yet earned any prestige level.
+    /// </summary>
+    /// <param name="data">The prestige data to render.</param>
+    /// <returns>A formatted prestige display string, or <see cref="string.Empty"/> if prestige level is 0.</returns>
     public static string GetPrestigeDisplay(PrestigeData data)
     {
         if (data.PrestigeLevel == 0) return "";

--- a/Systems/SkillTree.cs
+++ b/Systems/SkillTree.cs
@@ -1,19 +1,31 @@
 namespace Dungnz.Systems;
 using Dungnz.Models;
 
+/// <summary>Passive skills that can be unlocked by a player once they reach the required level.</summary>
 public enum Skill
 {
+    /// <summary>Increases the player's attack damage by 15% on each hit.</summary>
     PowerStrike,    // +15% damage on attacks
+    /// <summary>Permanently adds 3 to the player's defense stat when unlocked.</summary>
     IronSkin,       // +3 Defense permanently
+    /// <summary>Adds a 5% flat bonus to the player's dodge chance.</summary>
     Swiftness,      // +0.05 dodge bonus
+    /// <summary>Increases maximum mana by 10 and grants 5 mana regeneration per turn.</summary>
     ManaFlow,       // +10 max mana + mana regen +5/turn
+    /// <summary>Reduces all incoming damage by 5%.</summary>
     BattleHardened, // Take 5% less damage
 }
 
+/// <summary>
+/// Tracks which passive skills the player has unlocked and applies their stat bonuses.
+/// Skills are gated by minimum player level and can only be unlocked once per run.
+/// </summary>
 public class SkillTree
 {
     private readonly HashSet<Skill> _unlocked = new();
 
+    /// <summary>Returns <see langword="true"/> if the specified skill has been unlocked.</summary>
+    /// <param name="skill">The skill to query.</param>
     public bool IsUnlocked(Skill skill) => _unlocked.Contains(skill);
 
     /// <summary>
@@ -23,8 +35,16 @@ public class SkillTree
     /// <param name="skill">The skill to mark as learned.</param>
     public void Unlock(Skill skill) => _unlocked.Add(skill);
 
+    /// <summary>Gets a read-only collection of all skills that have been unlocked.</summary>
     public IReadOnlyCollection<Skill> UnlockedSkills => _unlocked;
 
+    /// <summary>
+    /// Attempts to unlock the specified skill for the player. Fails if the skill is already
+    /// unlocked or the player has not yet reached the required level.
+    /// </summary>
+    /// <param name="player">The player attempting to unlock the skill.</param>
+    /// <param name="skill">The skill to unlock.</param>
+    /// <returns><see langword="true"/> if the skill was successfully unlocked; otherwise <see langword="false"/>.</returns>
     public bool TryUnlock(Player player, Skill skill)
     {
         if (_unlocked.Contains(skill)) return false;
@@ -57,6 +77,11 @@ public class SkillTree
         // PowerStrike, Swiftness, BattleHardened are passive — applied in combat
     }
 
+    /// <summary>
+    /// Returns a short human-readable description of the passive bonus granted by the given skill.
+    /// </summary>
+    /// <param name="skill">The skill to describe.</param>
+    /// <returns>A string describing the skill's effect.</returns>
     public static string GetDescription(Skill skill) => skill switch {
         Skill.PowerStrike => "+15% attack damage",
         Skill.IronSkin => "+3 Defense (immediate)",


### PR DESCRIPTION
Adds `GenerateDocumentationFile=true` and `WarningsAsErrors=CS1591` to `Dungnz.csproj`. Adds XML summary comments to all public members. CI will now reject any PR that introduces a public member without an XML doc comment.