### PR TITLE
fix: shared EnemyFactory collection fixture — closes #147

### DIFF
--- a/Dungnz.Tests/DungeonGeneratorTests.cs
+++ b/Dungnz.Tests/DungeonGeneratorTests.cs
@@ -6,14 +6,9 @@ using Xunit;
 
 namespace Dungnz.Tests;
 
+[Collection("EnemyFactory")]
 public class DungeonGeneratorTests
 {
-    public DungeonGeneratorTests()
-    {
-        var enemyPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Data", "enemy-stats.json");
-        var itemPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Data", "item-stats.json");
-        EnemyFactory.Initialize(enemyPath, itemPath);
-    }
 
     [Fact]
     public void Generate_ReturnsNonNullRooms()

--- a/Dungnz.Tests/EnemyFactoryTests.cs
+++ b/Dungnz.Tests/EnemyFactoryTests.cs
@@ -6,15 +6,9 @@ using Xunit;
 
 namespace Dungnz.Tests;
 
+[Collection("EnemyFactory")]
 public class EnemyFactoryTests
 {
-    public EnemyFactoryTests()
-    {
-        // Initialize EnemyFactory with config files for tests
-        var enemyPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Data", "enemy-stats.json");
-        var itemPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Data", "item-stats.json");
-        EnemyFactory.Initialize(enemyPath, itemPath);
-    }
 
     [Fact]
     public void CreateRandom_ReturnsValidEnemy()

--- a/Dungnz.Tests/Helpers/EnemyFactoryFixture.cs
+++ b/Dungnz.Tests/Helpers/EnemyFactoryFixture.cs
@@ -1,0 +1,31 @@
+using Dungnz.Engine;
+using Xunit;
+
+namespace Dungnz.Tests.Helpers;
+
+/// <summary>
+/// Shared xUnit collection fixture that initialises <see cref="EnemyFactory"/> once
+/// for the entire test assembly. All test classes that directly or indirectly rely on
+/// <see cref="EnemyFactory"/> must belong to the <c>"EnemyFactory"</c> collection.
+/// </summary>
+public class EnemyFactoryFixture
+{
+    /// <summary>
+    /// Initialises <see cref="EnemyFactory"/> using the data files copied to the
+    /// test output directory.
+    /// </summary>
+    public EnemyFactoryFixture()
+    {
+        var enemyPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Data", "enemy-stats.json");
+        var itemPath  = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Data", "item-stats.json");
+        EnemyFactory.Initialize(enemyPath, itemPath);
+    }
+}
+
+/// <summary>
+/// xUnit collection definition for tests that depend on <see cref="EnemyFactory"/>
+/// static state. Sharing this collection ensures <see cref="EnemyFactoryFixture"/>
+/// runs exactly once before any test in the collection executes.
+/// </summary>
+[CollectionDefinition("EnemyFactory")]
+public class EnemyFactoryCollection : ICollectionFixture<EnemyFactoryFixture> { }


### PR DESCRIPTION
Fixes #147

Replaces per-constructor `EnemyFactory.Initialize()` calls with a shared xUnit `[Collection("EnemyFactory")]` fixture (`EnemyFactoryFixture`). The fixture runs `Initialize()` exactly once per assembly, so tests pass regardless of execution order or isolation level.

**Changes:**
- `Dungnz.Tests/Helpers/EnemyFactoryFixture.cs` — new shared fixture + collection definition
- `EnemyFactoryTests.cs` — removed per-constructor `Initialize()`, added `[Collection]` attribute
- `DungeonGeneratorTests.cs` — same

All 267 tests pass.