### PR TITLE
fix: correct item name row padding in ShowEquipmentComparison

### DIFF
--- a/.ai-team/decisions/inbox/coulson-pr223-review.md
+++ b/.ai-team/decisions/inbox/coulson-pr223-review.md
@@ -1,0 +1,30 @@
+# PR #223 Review — Barton: ColorizeDamage LastIndexOf fix + README
+
+**Reviewer:** Coulson (Lead)
+**Branch:** `squad/220-colorize-damage-fix`
+**Verdict:** ✅ APPROVED
+
+## Code Review
+
+### `ReplaceLastOccurrence` helper (CombatEngine.cs)
+- Clean `private static` helper using `LastIndexOf` — correct approach
+- Null-safe: returns `source` unchanged if `find` not found
+- XML doc accurately explains why last-occurrence is the right semantic
+- Both call sites updated: normal damage and crit path
+
+### `ColorizeDamage` changes
+- `string.Replace` → `ReplaceLastOccurrence` on both code paths (normal + crit)
+- Preserves existing colorization logic (BrightRed for damage, Yellow+Bold for crits)
+- Fix directly addresses Issue #220: when damage number appears in enemy name, only the trailing (actual damage) occurrence is colorized
+
+### README update
+- Accurately documents the `LastIndexOf` behaviour
+- Placed in the correct section (Display & Colours)
+- Concise, informative
+
+### Build & Tests
+- ✅ All 267 tests pass on this branch
+- No new warnings introduced
+
+## Decision
+Merge to master. Clean, minimal, correct fix.

--- a/.ai-team/decisions/inbox/coulson-pr224-review.md
+++ b/.ai-team/decisions/inbox/coulson-pr224-review.md
@@ -1,0 +1,30 @@
+# PR #224 Review — Coulson
+
+**PR:** #224 `squad/219-221-222-display-fixes`
+**Verdict:** ✅ APPROVED
+**Date:** 2025-07-15
+
+## Summary
+
+All three follow-up fixes from PR #218 code review are correctly addressed:
+
+### #219 — README health threshold table
+The table now matches the actual `HealthColor()` switch expression:
+- `> 70%` → Green
+- `40–70%` → Yellow
+- `20–40%` → Red
+- `≤ 20%` → Bright Red
+
+Verified against `Systems/ColorCodes.HealthColor()`. ✅
+
+### #221 — `ShowEquipmentComparison` right-border alignment
+Padding now uses `StripAnsiCodes()` to compute visible character width before calculating whitespace. The `attackPrefix.Length - 1` correctly excludes the left `║` border from the inner-width calculation, and `innerWidth = 39` matches the box geometry. ✅
+
+### #222 — `ShowPlayerStats` refactored to use `ShowColoredStat()`
+All six inline `Colorize` / manual ANSI calls replaced with `ShowColoredStat(label, value, color)`. HP and Mana use dynamic threshold colors; Attack/Defense/Gold/XP use static colors. Label padding via `{label,-8}` in the helper is consistent. ✅
+
+### Bonus: #220 — `ColorizeDamage` last-occurrence fix
+`ReplaceLastOccurrence` helper added to `CombatEngine` — correct `LastIndexOf`-based implementation. Both call sites updated. ✅
+
+### Build & Tests
+`dotnet test` passes (all tests, 0 failures). ✅

--- a/.ai-team/decisions/inbox/coulson-pr225-review.md
+++ b/.ai-team/decisions/inbox/coulson-pr225-review.md
@@ -1,0 +1,48 @@
+# PR #225 Review — Romanoff: Edge-case tests for #220 and #221
+
+**Reviewer:** Coulson (Lead)
+**Branch:** `squad/220-221-tests`
+**Verdict:** ✅ APPROVED (with note on alignment test failures)
+
+## Rebase Performed
+Branch rebased onto master (which now includes PR #224 fix for #219/#221/#222). Redundant fix commits dropped cleanly. Force-pushed.
+
+## ColorizeDamage Tests (ColorizeDamageTests.cs) — ✅ PASS (2/2)
+
+### Test quality
+- Proper xUnit `[Fact]` tests with clear Arrange-Act-Assert structure
+- `ColorizeDamage_NormalCase_OnlyColorizesDamageNumber` — baseline: single occurrence, correct colorization
+- `ColorizeDamage_EdgeCase_OnlyLastOccurrenceIsColorized_WhenDamageAppearsInEnemyName` — the #220 edge case: enemy named "5" dealing 5 damage, verifies only the trailing "5" is colorized
+- `CountColorized` helper is clean and reusable
+- Uses `RawCombatMessages` (new property on FakeDisplayService) to inspect ANSI-intact output — good design
+
+### FakeDisplayService change
+- Added `RawCombatMessages` list that stores messages before ANSI stripping
+- Minimal, non-breaking addition — existing `CombatMessages` (stripped) still works for all other tests
+
+## ShowEquipmentComparison Alignment Tests (ShowEquipmentComparisonAlignmentTests.cs) — ❌ FAIL (2/2)
+
+### Test quality — tests are CORRECT
+- `ShowEquipmentComparison_AllBoxLines_HaveConsistentVisualWidth_WhenDeltasAreColoured` — verifies every `║`-prefixed line matches border width after ANSI stripping
+- `ShowEquipmentComparison_RightBorderChar_AppearsAtConsistentColumn_WhenOnlyAttackChanges` — mixed case: one delta row, one plain row
+- Both use `IDisposable` pattern with `StringWriter` console capture — clean
+- `BoxWidth` helper correctly derives expected width from the `╔═══╗` border line
+
+### Why they fail
+The tests correctly detect a **remaining alignment bug**: master's #221 fix (PR #224) corrected the Attack/Defense delta rows but did NOT fix the non-delta content rows:
+- `║ Current:  {name,-27}║` → produces 40-char lines
+- `║ New:      {name,-27}║` → produces 40-char lines
+- Border `╔═══...═══╗` → 41 chars
+
+The padding should be `,-28` (not `,-27`) to match the 41-char border width. This is a **production code bug**, not a test bug.
+
+### Action needed
+**Follow-up required:** Fix `ShowEquipmentComparison` non-delta rows to use correct padding (`,-28`). File as follow-up to #221 or have Barton fix before merge.
+
+## Test Results Summary
+- ColorizeDamage tests: 2/2 PASS ✅
+- Alignment tests: 2/2 FAIL ❌ (correct tests, incomplete production fix)
+- All other tests: 269/269 PASS ✅
+
+## Decision
+Tests are well-structured, correctly written, and exercise the right edge cases. Approve the test code. The alignment test failures are a signal that the #221 fix needs a follow-up patch to the `Current:`/`New:` rows in `ShowEquipmentComparison`. **Do not merge until alignment fix lands** (or tests will break CI).

--- a/Display/DisplayService.cs
+++ b/Display/DisplayService.cs
@@ -407,13 +407,13 @@ public class ConsoleDisplayService : IDisplayService
         // Current item
         Console.Write("║ Current:  ");
         if (oldItem != null)
-            Console.Write($"{oldItem.Name,-27}");
+            Console.Write($"{oldItem.Name,-28}");
         else
-            Console.Write($"{"(none)",-27}");
+            Console.Write($"{"(none)",-28}");
         Console.WriteLine("║");
         
         // New item
-        Console.WriteLine($"║ New:      {newItem.Name,-27}║");
+        Console.WriteLine($"║ New:      {newItem.Name,-28}║");
         Console.WriteLine("╠═══════════════════════════════════════╣");
         
         // Calculate deltas


### PR DESCRIPTION
Follow-up to #224. Fixes the Current:/New: row padding to match the box border width — alignment tests in PR #225 will pass after this.

Closes #221 (fully)