### PR TITLE
chore: ASCII art feature session log

### DIFF
--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -11148,3 +11148,31 @@ Adding ASCII art for enemies is **architecturally feasible and low-risk**. The d
 
 **Phase 2 possibilities:** Per-type color theming, elite/boss variants, animated frames.
 
+
+
+---
+
+## ASCII Art Feature
+
+### 2026-02-24: Issues Created
+**By:** Coulson  
+**What:** Created 5 GitHub issues for ASCII art enemy encounter feature  
+**Why:** Anthony approved implementation following unanimous feasibility recommendation  
+**Issues:**
+- #314 — feat: Add AsciiArt property to Enemy model and EnemyStats (Hill)
+- #315 — feat: Wire ShowEnemyArt into CombatEngine encounter start (Barton)
+- #316 — test: Write tests for ShowEnemyArt display and combat integration (Romanoff)
+- #317 — feat: Add ShowEnemyArt method to IDisplayService and DisplayService (Hill)
+- #318 — feat: Add ASCII art content to all enemies in enemy-stats.json (Barton)
+
+### 2026-02-23: Implementation Complete
+**By:** Hill, Barton, Romanoff  
+**What:** Full implementation of ASCII art for enemy encounters merged to master  
+**Decisions made:**
+- `AsciiArt string[]` stored directly on `EnemyStats` / `Enemy` — data-driven, follows `BossNarration` precedent
+- `ShowEnemyArt(Enemy)` placed on `IDisplayService` (not inlined in `CombatEngine`) — keeps display logic in display layer
+- 36-char box width with ANSI color keyed to enemy tier — consistent with existing card widths
+- Art called after `ShowCombatStart` in `CombatEngine.RunCombat()` — natural insertion point
+- Regular enemies: 4–6 lines; Bosses: 6–8 lines; all ≤ 34 chars wide
+- Tests use `FakeDisplayService` recording — no snapshot tests (per feasibility risk mitigation)
+**Outcome:** 5 issues closed, 3 PRs merged (#319, #320, #321), 4 new tests, zero regressions

--- a/.ai-team/log/2026-02-23-ascii-art-feature-implementation.md
+++ b/.ai-team/log/2026-02-23-ascii-art-feature-implementation.md
@@ -1,0 +1,67 @@
+# Session: ASCII Art Feature — Implementation
+
+**Date:** 2026-02-23  
+**Participants:** Hill, Barton, Romanoff  
+**Status:** Complete
+
+---
+
+## Summary
+
+Implemented ASCII art display for enemy encounters across the full stack: model, display layer, combat wiring, data, and tests. All 5 GitHub issues closed, 3 PRs merged to master. Zero regressions. Test count: 427 → 431.
+
+---
+
+## Issues Closed
+
+| Issue | Title | Assignee |
+|-------|-------|----------|
+| #314 | feat: Add AsciiArt property to Enemy model and EnemyStats | Hill |
+| #315 | feat: Wire ShowEnemyArt into CombatEngine encounter start | Barton |
+| #316 | test: Write tests for ShowEnemyArt display and combat integration | Romanoff |
+| #317 | feat: Add ShowEnemyArt method to IDisplayService and DisplayService | Hill |
+| #318 | feat: Add ASCII art content to all enemies in enemy-stats.json | Barton |
+
+---
+
+## PRs Merged
+
+| PR | Title | Author |
+|----|-------|--------|
+| #319 | feat: AsciiArt model + ShowEnemyArt display method | Hill |
+| #320 | feat: Wire ShowEnemyArt into combat + ASCII art content for all 23 enemies | Barton |
+| #321 | test: ShowEnemyArt tests | Romanoff |
+
+---
+
+## Work Done
+
+### Hill — Model + Display Layer
+- Added `AsciiArt string[]` property to `EnemyStats` and `Enemy` base class
+- Added `ShowEnemyArt(Enemy)` to `IDisplayService` and `DisplayService`
+  - 36-char box with ANSI color keyed to enemy tier
+- Added stub implementations to `FakeDisplayService` and `TestDisplayService`
+
+### Barton — Combat Wiring + Data
+- Wired `ShowEnemyArt(enemy)` call into `CombatEngine.RunCombat()` immediately after `ShowCombatStart`
+- Added `AsciiArt` arrays to all 23 enemies in `Data/enemy-stats.json`
+  - Regular enemies: 4–6 lines, all ≤ 34 chars wide
+  - Bosses: 6–8 lines, all ≤ 34 chars wide
+
+### Romanoff — Tests
+- Created `Dungnz.Tests/Display/ShowEnemyArtTests.cs` with 4 tests:
+  1. No-op on empty art array
+  2. Art lines recorded via `FakeDisplayService`
+  3. All lines in JSON data ≤ 34 chars (data integrity)
+  4. `CombatEngine` invokes `ShowEnemyArt` during combat
+
+---
+
+## Test Count
+
+| | Count |
+|---|---|
+| Before | 427 |
+| After | 431 |
+| New tests | 4 |
+| Regressions | 0 |


### PR DESCRIPTION
## Session Log: ASCII Art Feature Implementation

Adds the Scribe's session log for the ASCII art enemy encounter feature, and merges Coulson's inbox decision entry into `decisions.md`.

### Files changed
- `.ai-team/log/2026-02-23-ascii-art-feature-implementation.md` — new session log
- `.ai-team/decisions.md` — new "ASCII Art Feature" section (merged from `decisions/inbox/coulson-ascii-art-issues.md`)

### Session summary
- Issues closed: #314, #315, #316, #317, #318
- PRs merged: #319 (Hill), #320 (Barton), #321 (Romanoff)
- Tests: 427 → 431 (4 new, 0 regressions)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>