### PR TITLE
Items: Scale floor loot by depth + enemy-specific themed drops

### DIFF
--- a/Engine/EnemyFactory.cs
+++ b/Engine/EnemyFactory.cs
@@ -15,6 +15,9 @@ public static class EnemyFactory
     private static Dictionary<string, EnemyStats>? _enemyConfig;
     private static List<ItemStats>? _itemConfig;
 
+    /// <summary>Exposes the loaded item configuration for use by other engine components (e.g., DungeonGenerator).</summary>
+    public static List<ItemStats>? Items => _itemConfig;
+
     /// <summary>
     /// Loads enemy base-stat and item-drop configuration from external data files so
     /// that all subsequent factory methods have data to work from. Must be called once

--- a/Systems/Enemies/DarkKnight.cs
+++ b/Systems/Enemies/DarkKnight.cs
@@ -63,6 +63,12 @@ public class DarkKnight : Enemy
             {
                 LootTable.AddDrop(ItemConfig.CreateItem(knightArmor), 0.4);
             }
+
+            var studdedArmor = itemConfig.FirstOrDefault(i => i.Name == "Studded Armor");
+            if (studdedArmor != null)
+            {
+                LootTable.AddDrop(ItemConfig.CreateItem(studdedArmor), 0.25);
+            }
         }
         else
         {
@@ -82,6 +88,15 @@ public class DarkKnight : Enemy
                 Description = "Heavy plated armor.",
                 Tier = ItemTier.Uncommon
             }, 0.4);
+            LootTable.AddDrop(new Item
+            {
+                Name = "Studded Armor",
+                Type = ItemType.Armor,
+                DefenseBonus = 8,
+                IsEquippable = true,
+                Description = "Leather reinforced with iron rivets.",
+                Tier = ItemTier.Uncommon
+            }, 0.25);
         }
     }
 }

--- a/Systems/Enemies/GoblinShaman.cs
+++ b/Systems/Enemies/GoblinShaman.cs
@@ -46,5 +46,23 @@ public class GoblinShaman : Enemy
             XPValue = 25;
             LootTable = new LootTable(minGold: 5, maxGold: 15);
         }
+
+        if (itemConfig != null)
+        {
+            var antidote = itemConfig.FirstOrDefault(i => i.Name == "Antidote");
+            if (antidote != null)
+                LootTable.AddDrop(ItemConfig.CreateItem(antidote), 0.4);
+        }
+        else
+        {
+            LootTable.AddDrop(new Item
+            {
+                Name = "Antidote",
+                Type = ItemType.Consumable,
+                HealAmount = 8,
+                Description = "A bitter green liquid that neutralises toxins.",
+                Tier = ItemTier.Common
+            }, 0.4);
+        }
     }
 }

--- a/Systems/Enemies/Mimic.cs
+++ b/Systems/Enemies/Mimic.cs
@@ -46,5 +46,28 @@ public class Mimic : Enemy
             XPValue = 40;
             LootTable = new LootTable(minGold: 10, maxGold: 25);
         }
+
+        // Mimic always drops a Rare item — it is the reward for surviving the ambush
+        if (itemConfig != null)
+        {
+            var rareItems = itemConfig.Where(i => i.Tier.Equals("Rare", StringComparison.OrdinalIgnoreCase)
+                                                  && i.Name != "Boss Key").ToList();
+            if (rareItems.Count > 0)
+            {
+                var pick = rareItems[new Random().Next(rareItems.Count)];
+                LootTable.AddDrop(ItemConfig.CreateItem(pick), 1.0);
+            }
+        }
+        else
+        {
+            LootTable.AddDrop(new Item
+            {
+                Name = "Phoenix Feather",
+                Type = ItemType.Consumable,
+                HealAmount = 60,
+                Description = "Channels the fire of rebirth into your wounds.",
+                Tier = ItemTier.Rare
+            }, 1.0);
+        }
     }
 }

--- a/Systems/Enemies/StoneGolem.cs
+++ b/Systems/Enemies/StoneGolem.cs
@@ -46,5 +46,22 @@ public class StoneGolem : Enemy
             XPValue = 50;
             LootTable = new LootTable(minGold: 10, maxGold: 25);
         }
+
+        if (itemConfig != null)
+        {
+            var ironOre = itemConfig.FirstOrDefault(i => i.Name == "Iron Ore");
+            if (ironOre != null)
+                LootTable.AddDrop(ItemConfig.CreateItem(ironOre), 0.25);
+        }
+        else
+        {
+            LootTable.AddDrop(new Item
+            {
+                Name = "Iron Ore",
+                Type = ItemType.Consumable,
+                Description = "Raw iron. Could be useful for a blacksmith.",
+                Tier = ItemTier.Common
+            }, 0.25);
+        }
     }
 }

--- a/Systems/Enemies/VampireLord.cs
+++ b/Systems/Enemies/VampireLord.cs
@@ -46,5 +46,23 @@ public class VampireLord : Enemy
             XPValue = 60;
             LootTable = new LootTable(minGold: 15, maxGold: 30);
         }
+
+        if (itemConfig != null)
+        {
+            var bloodVial = itemConfig.FirstOrDefault(i => i.Name == "Blood Vial");
+            if (bloodVial != null)
+                LootTable.AddDrop(ItemConfig.CreateItem(bloodVial), 0.45);
+        }
+        else
+        {
+            LootTable.AddDrop(new Item
+            {
+                Name = "Blood Vial",
+                Type = ItemType.Consumable,
+                HealAmount = 30,
+                Description = "Vampire's blood. Bitter, warm. Works.",
+                Tier = ItemTier.Rare
+            }, 0.45);
+        }
     }
 }

--- a/Systems/Enemies/Wraith.cs
+++ b/Systems/Enemies/Wraith.cs
@@ -46,5 +46,23 @@ public class Wraith : Enemy
             XPValue = 35;
             LootTable = new LootTable(minGold: 8, maxGold: 20);
         }
+
+        if (itemConfig != null)
+        {
+            var shadowEssence = itemConfig.FirstOrDefault(i => i.Name == "Shadow Essence");
+            if (shadowEssence != null)
+                LootTable.AddDrop(ItemConfig.CreateItem(shadowEssence), 0.20);
+        }
+        else
+        {
+            LootTable.AddDrop(new Item
+            {
+                Name = "Shadow Essence",
+                Type = ItemType.Consumable,
+                HealAmount = 20,
+                Description = "Distilled shadow. Restores health when consumed — somehow.",
+                Tier = ItemTier.Rare
+            }, 0.20);
+        }
     }
 }


### PR DESCRIPTION
Closes #332
Closes #337

Floor-found items now scale with dungeon depth: floors 1-2 drop Common items, floors 3-4 drop Uncommon, floor 5 drops Rare. Enemy-specific drops added for 6 enemy types.

### B4: Floor Loot Scaling
- `DungeonGenerator.CreateRandomItem()` now takes `floor` parameter and uses `ItemConfig.GetByTier()` to pick from the correct tier pool
- `EnemyFactory.Items` property added to expose loaded item config to the generator
- Fallback to Health Potion when item config not loaded (test safety)

### C3: Enemy-Specific Drops
| Enemy | Drop | Chance |
|-------|------|--------|
| Goblin Shaman | Antidote | 40% |
| Stone Golem | Iron Ore | 25% |
| Wraith | Shadow Essence | 20% |
| Vampire Lord | Blood Vial | 45% |
| Dark Knight | Studded Armor | 25% |
| Mimic | Random Rare item | 100% |

### New items in item-stats.json
- `iron-ore` — Common, Consumable (crafting material)
- `shadow-essence` — Rare, Consumable (+20 HP)
- `blood-vial` — Rare, Consumable (+30 HP)

Note: Goblin 'Small Gold Pouch' deferred — needs a per-roll gold bonus mechanic in LootTable not currently supported; gold already covered by min/max range.

All 431 tests pass.