### PR TITLE
Narration: Room state tracking, cleared-room flavor, floor transition ceremonies

### DIFF
--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -262,6 +262,13 @@ public class GameLoop
         if (_narration.Chance(0.15))
             _display.ShowMessage(_narration.Pick(AmbientEvents.ForFloor(_currentFloor)));
 
+        // Show revisit flavor when returning to an already-explored room
+        if (_currentRoom.Visited)
+        {
+            _display.ShowMessage(_narration.Pick(RoomStateNarration.RevisitedRoom));
+            _currentRoom.State = RoomState.Revisited;
+        }
+
         _display.ShowRoom(_currentRoom);
         _currentRoom.Visited = true;
         _events?.RaiseRoomEntered(_player, _currentRoom, previousRoom);
@@ -328,6 +335,8 @@ public class GameLoop
                 var enemyName = _currentRoom.Enemy!.Name;
                 _currentRoom.Enemy = null;
                 _display.ShowMessage(_narration.Pick(_postCombatLines, enemyName));
+                _currentRoom.State = RoomState.Cleared;
+                _display.ShowMessage(_narration.Pick(RoomStateNarration.ClearedRoom));
             }
 
             if (result == CombatResult.Fled)
@@ -598,6 +607,8 @@ public class GameLoop
         }
 
         _currentFloor++;
+        foreach (var line in FloorTransitionNarration.GetSequence(_currentFloor))
+            _display.ShowMessage(line);
         _display.ShowMessage($"You descend deeper into the dungeon... Floor {_currentFloor}");
 
         float floorMult = 1.0f + (_currentFloor - 1) * 0.5f;

--- a/Models/Room.cs
+++ b/Models/Room.cs
@@ -98,4 +98,18 @@ public class Room
 
     /// <summary>Gets or sets the environmental hazard in this room that damages the player on entry.</summary>
     public HazardType Hazard { get; set; } = HazardType.None;
+
+    /// <summary>Gets or sets the narrative state of this room: Fresh on first entry, Cleared after its enemy is defeated, Revisited on subsequent entries.</summary>
+    public RoomState State { get; set; } = RoomState.Fresh;
+}
+
+/// <summary>Tracks the narrative state of a room for flavor text selection.</summary>
+public enum RoomState
+{
+    /// <summary>Room has not yet been entered by the player.</summary>
+    Fresh,
+    /// <summary>Room has been cleared of its enemy.</summary>
+    Cleared,
+    /// <summary>Room has been visited before.</summary>
+    Revisited
 }

--- a/Systems/FloorTransitionNarration.cs
+++ b/Systems/FloorTransitionNarration.cs
@@ -1,0 +1,50 @@
+namespace Dungnz.Systems;
+
+/// <summary>
+/// Sequential dramatic lines shown when the player descends to a new floor.
+/// Each entry is a 2-3 line sequence displayed in order before the floor loads.
+/// </summary>
+public static class FloorTransitionNarration
+{
+    /// <summary>Descent into Floor 2: the Skeleton Catacombs.</summary>
+    public static readonly string[] ToFloor2 =
+    {
+        "The goblin noise fades above you.",
+        "Something older waits below — cold, patient, stripped of everything soft.",
+        "Floor 2. The air smells of dust and forgotten names."
+    };
+
+    /// <summary>Descent into Floor 3: the Troll Warrens.</summary>
+    public static readonly string[] ToFloor3 =
+    {
+        "The cold bone-smell of the catacombs gives way to something warmer. Worse.",
+        "Something large moves in the dark below. You hear it breathing before you see anything.",
+        "Floor 3. Whatever lives here is very much alive."
+    };
+
+    /// <summary>Descent into Floor 4: the Shadow Realm.</summary>
+    public static readonly string[] ToFloor4 =
+    {
+        "The torchlight doesn't carry down here the way it should.",
+        "The walls look solid. They don't feel solid. Reality is getting loose at the edges.",
+        "Floor 4. The shadows move when nothing else does."
+    };
+
+    /// <summary>Descent into Floor 5: the Dragon's Lair.</summary>
+    public static readonly string[] ToFloor5 =
+    {
+        "The air arrives scorched, as if the dark itself is on fire.",
+        "Your chest tightens. Not from fear — from heat. The stones are warm under your boots.",
+        "Floor 5. There is no floor after this one."
+    };
+
+    /// <summary>Returns the transition sequence for the given target floor, or an empty array if no sequence exists.</summary>
+    public static string[] GetSequence(int targetFloor) => targetFloor switch
+    {
+        2 => ToFloor2,
+        3 => ToFloor3,
+        4 => ToFloor4,
+        5 => ToFloor5,
+        _ => Array.Empty<string>()
+    };
+}

--- a/Systems/RoomStateNarration.cs
+++ b/Systems/RoomStateNarration.cs
@@ -1,0 +1,38 @@
+namespace Dungnz.Systems;
+
+/// <summary>
+/// Flavor text pools for room state transitions: the grim aftermath of a cleared room,
+/// and the uneasy familiarity of revisiting somewhere you've already been.
+/// </summary>
+public static class RoomStateNarration
+{
+    /// <summary>Shown briefly after the last enemy in a room is killed.</summary>
+    public static readonly string[] ClearedRoom =
+    {
+        "The floor is darker now.",
+        "Something drips. You don't look up.",
+        "It's quiet again. Not peaceful — just quiet.",
+        "The silence that follows a kill is its own kind of sound.",
+        "You breathe. The room doesn't.",
+        "Whatever this place was, it's a little more yours now.",
+        "The air smells of copper and effort.",
+        "Nothing left here but what you brought with you.",
+        "Still. Everything holds very still.",
+        "The fight is behind you. The dungeon isn't."
+    };
+
+    /// <summary>Shown when the player enters a room they've already explored.</summary>
+    public static readonly string[] RevisitedRoom =
+    {
+        "You've been here. The smell hasn't improved.",
+        "The marks of your passage are already fading.",
+        "Same walls. Different you.",
+        "Familiar in the way that bad memories are familiar.",
+        "You know this room. It doesn't care.",
+        "The quiet here is old — you didn't start it.",
+        "Your footprints are already in the dust.",
+        "Nothing has changed. Nothing ever does, down here.",
+        "You've walked this floor before. The stones remember.",
+        "Returning doesn't make it safer."
+    };
+}


### PR DESCRIPTION
Closes #324
Closes #328

**A1 - Room State Narration:**
- RoomState enum on Room model (Fresh / Cleared / Revisited)
- 10 grim aftermath lines for cleared rooms
- 10 uneasy revisit lines for returning to explored rooms

**A5 - Floor Transition Ceremony:**
- Dramatic 3-line sequences for descending to each floor (2-5)
- Each floor has distinct atmospheric theme: cold bone-silence → brutish warmth → thinning reality → scorched finality