### PR TITLE
DevOps: Fix squad-release.yml, squad-ci.yml, and squad-preview.yml to use dotnet commands

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -16,9 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
-          node-version: 22
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
 
       - name: Run tests
-        run: node --test test/*.test.js
+        run: dotnet test Dungnz.Tests --verbosity normal

--- a/.github/workflows/squad-preview.yml
+++ b/.github/workflows/squad-preview.yml
@@ -13,12 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
-          node-version: 22
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
 
       - name: Run tests
-        run: node --test test/*.test.js
+        run: dotnet test Dungnz.Tests --verbosity normal
 
       - name: Check no .ai-team/ files are tracked
         run: |
@@ -27,12 +31,3 @@ jobs:
             exit 1
           fi
           echo "✅ No .ai-team/ files tracked — clean for release."
-
-      - name: Validate package.json version
-        run: |
-          VERSION=$(node -e "console.log(require('./package.json').version)")
-          if [ -z "$VERSION" ]; then
-            echo "::error::❌ No version field found in package.json."
-            exit 1
-          fi
-          echo "✅ package.json version: $VERSION"

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -15,20 +15,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
-          node-version: 22
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
 
       - name: Run tests
-        run: node --test test/*.test.js
+        run: dotnet test Dungnz.Tests --no-build --verbosity normal
 
-      - name: Read version from package.json
+      - name: Generate version tag
         id: version
         run: |
-          VERSION=$(node -e "console.log(require('./package.json').version)")
+          VERSION=$(git describe --tags --always | sed 's/^v//')
+          TAG="v$(date +%Y.%m.%d)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-          echo "📦 Version: $VERSION (tag: v$VERSION)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "📦 Version: $VERSION (tag: $TAG)"
 
       - name: Check if tag already exists
         id: check_tag


### PR DESCRIPTION
Fixes three workflows (squad-release.yml, squad-ci.yml, squad-preview.yml) which incorrectly ran node --test on a .NET C# project.

**Changes:**
- Replaced actions/setup-node@v4 with actions/setup-dotnet@v4
- Added dotnet restore step to each workflow
- Changed test command to 'dotnet test Dungnz.Tests'
- squad-release.yml: Updated version detection to use git describe and date-based versioning
- squad-preview.yml: Removed package.json validation (not applicable to .NET)

This aligns the CI/CD pipelines with the actual project technology stack.