### PR TITLE
feat(models): add ArmorSlot enum and Slot property to Item (#405)

### DIFF
--- a/Models/ArmorSlot.cs
+++ b/Models/ArmorSlot.cs
@@ -1,0 +1,27 @@
+namespace Dungnz.Models;
+
+/// <summary>
+/// Identifies the body slot that an armor piece occupies when equipped.
+/// Weapons, accessories, consumables, and gold use <see cref="None"/>.
+/// </summary>
+public enum ArmorSlot
+{
+    /// <summary>Not a slot-occupying armor piece (weapons, accessories, consumables, gold).</summary>
+    None,
+    /// <summary>Head slot — helms, hoods, crowns.</summary>
+    Head,
+    /// <summary>Shoulder slot — pauldrons, mantles.</summary>
+    Shoulders,
+    /// <summary>Chest slot — cuirasses, robes, tunics, chainmail.</summary>
+    Chest,
+    /// <summary>Hand slot — gauntlets, gloves, bracers.</summary>
+    Hands,
+    /// <summary>Leg slot — greaves, leggings, chaps.</summary>
+    Legs,
+    /// <summary>Foot slot — boots, sabatons, shoes.</summary>
+    Feet,
+    /// <summary>Back slot — cloaks, capes.</summary>
+    Back,
+    /// <summary>Off-hand slot — shields and spell focuses.</summary>
+    OffHand,
+}

--- a/Models/Item.cs
+++ b/Models/Item.cs
@@ -72,6 +72,12 @@ public class Item
     public bool IsEquippable { get; set; }
 
     /// <summary>
+    /// The armor slot this item occupies when equipped.
+    /// <see cref="ArmorSlot.None"/> for weapons, accessories, consumables, and gold.
+    /// </summary>
+    public ArmorSlot Slot { get; set; } = ArmorSlot.None;
+
+    /// <summary>
     /// Gets or sets the amount of mana restored to the player when this consumable item is used.
     /// Distinct from <see cref="MaxManaBonus"/>, which permanently raises the player's mana cap.
     /// </summary>

--- a/Systems/ItemConfig.cs
+++ b/Systems/ItemConfig.cs
@@ -65,6 +65,9 @@ public record ItemStats
 
     /// <summary>Optional set identifier linking this item to a named equipment set (e.g. "shadowstalker").</summary>
     public string? SetId { get; init; }
+
+    /// <summary>The armor slot this item occupies when equipped. Defaults to <c>"None"</c> for non-armor items.</summary>
+    public string Slot { get; init; } = "None";
 }
 
 /// <summary>
@@ -205,7 +208,8 @@ public static class ItemConfig
             SellPrice = stats.SellPrice,
             ClassRestriction = stats.ClassRestriction,
             PassiveEffectId = stats.PassiveEffectId,
-            SetId = stats.SetId
+            SetId = stats.SetId,
+            Slot = Enum.TryParse<ArmorSlot>(stats.Slot, ignoreCase: true, out var slot) ? slot : ArmorSlot.None,
         };
     }
 }


### PR DESCRIPTION
Closes #405.

## Changes

- **** — New enum with 9 values: `None`, `Head`, `Shoulders`, `Chest`, `Hands`, `Legs`, `Feet`, `Back`, `OffHand`.
- **** — Added `public ArmorSlot Slot { get; set; } = ArmorSlot.None;` near `IsEquippable`.
- **** — Added `string Slot` to `ItemStats` (defaults to `"None"`) for JSON deserialization; mapped to `ArmorSlot` via `Enum.TryParse` in `CreateItem`.

Items without a `"Slot"` field in `item-stats.json` correctly default to `ArmorSlot.None`. Items with e.g. `"Slot": "Chest"` will parse correctly. Build: 0 errors. Tests: 604/604 passed.