### PR TITLE
feat(engine): update LootTable and DungeonGenerator for all armor slots (#409)

### DIFF
--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -938,7 +938,7 @@ public class GameLoop
     private void GiveArmoryLoot(bool uncommon)
     {
         var tier = uncommon ? Models.ItemTier.Uncommon : Models.ItemTier.Rare;
-        var loot = Models.LootTable.RollTier(tier);
+        var loot = Models.LootTable.RollArmorTier(tier);
         if (loot != null)
         {
             _player.Inventory.Add(loot);

--- a/Models/LootTable.cs
+++ b/Models/LootTable.cs
@@ -77,6 +77,30 @@ public class LootTable
     }
 
     /// <summary>
+    /// Picks a random <see cref="ItemType.Armor"/> item of the specified tier from the shared
+    /// tier pools. Falls back to any item in the tier when no armor items are available.
+    /// Returns <see langword="null"/> if the tier pool is entirely empty.
+    /// </summary>
+    /// <param name="tier">The desired item tier.</param>
+    /// <returns>A randomly selected armor item (or any item if no armor exists in that tier), or <see langword="null"/>.</returns>
+    public static Item? RollArmorTier(ItemTier tier)
+    {
+        IReadOnlyList<Item>? fullPool = tier switch
+        {
+            ItemTier.Common    => _sharedTier1 ?? FallbackTier1,
+            ItemTier.Uncommon  => _sharedTier2 ?? FallbackTier2,
+            ItemTier.Rare      => _sharedTier3 ?? FallbackTier3,
+            ItemTier.Legendary => _sharedLegendary ?? FallbackLegendary,
+            _                  => _sharedTier2 ?? FallbackTier2
+        };
+        if (fullPool.Count == 0) return null;
+
+        var armorPool = fullPool.Where(i => i.Type == ItemType.Armor).ToList();
+        var pool = armorPool.Count > 0 ? (IList<Item>)armorPool : (IList<Item>)fullPool.ToList();
+        return pool[Random.Shared.Next(pool.Count)].Clone();
+    }
+
+    /// <summary>
     /// Initialises a new <see cref="LootTable"/> with an optional random-number generator and
     /// a gold drop range.
     /// </summary>


### PR DESCRIPTION
Closes #409.

## What was found

**Tier pool construction was already correct.** `ItemConfig.GetByTier()` filters only by `Tier` (Common/Uncommon/Rare/Legendary) and `MerchantExclusive`, with no slot or `ItemType` restriction. All 27 armor items across all `ArmorSlot` values (Head, Chest, Legs, Hands, Feet, Back, Shoulders, OffHand) are already included in the shared tier pools. `DungeonGenerator.CreateRandomItem()` and boss Legendary drops also had no implicit slot filter.

## What was changed

### `Models/LootTable.cs`
- Added `RollArmorTier(ItemTier tier)` static method that filters the tier pool to `ItemType.Armor` items and falls back to the full tier pool when no armor items exist in that tier.

### `Engine/GameLoop.cs`
- Updated `GiveArmoryLoot()` to call `LootTable.RollArmorTier()` instead of `LootTable.RollTier()`, so the Contested Armory special room now prefers armor-category drops (any slot) while gracefully falling back to any item if the tier has none.

## Build & Test
- `dotnet build` — 0 errors, 30 pre-existing warnings
- `dotnet test` — 604 passed, 0 failed