### PR TITLE
feat(narration): combat ambient + NPC/shrine/merchant flavor (#454, #455)

### DIFF
--- a/Systems/MerchantNarration.cs
+++ b/Systems/MerchantNarration.cs
@@ -81,4 +81,96 @@ public static class MerchantNarration
     public static string GetAfterSale() => AfterSale[_rng.Next(AfterSale.Length)];
     /// <summary>Returns a random line from <see cref="NoSell"/>.</summary>
     public static string GetNoSell() => NoSell[_rng.Next(NoSell.Length)];
+
+    // Shown when the player sells a Legendary item
+    /// <summary>Lines shown when the player sells a Legendary-tier item.</summary>
+    public static readonly string[] LegendarySold =
+    {
+        "\"Where did you get this? ...I won't ask. Here.\"",
+        "The merchant's eyes widen — just for a moment. \"I'll pay well for this. Don't tell anyone.\"",
+        "\"This is... exceptional. I won't question the blood on it. Take your coin.\""
+    };
+
+    // Shown when player tries to buy but cannot afford it
+    /// <summary>Lines shown when the player tries to buy but does not have enough gold.</summary>
+    public static readonly string[] CantAfford =
+    {
+        "\"...Come back when you have the coin.\"",
+        "\"Not enough. The dungeon doesn't do credit.\"",
+        "\"That's sweet. But no.\""
+    };
+
+    // Shown when player's inventory is full
+    /// <summary>Lines shown when the player's inventory is full.</summary>
+    public static readonly string[] InventoryFull =
+    {
+        "\"You couldn't carry another thing. Clear some space.\"",
+        "\"You're already overloaded. Come back when you've made room.\"",
+        "\"No room. Drop something first.\""
+    };
+
+    // Floor-aware greetings
+
+    /// <summary>Merchant greetings for floors 1-2 (newcomer energy).</summary>
+    public static readonly string[] GreetingsFloor1_2 =
+    {
+        "\"Welcome, brave fool. What'll it be?\"",
+        "\"First few floors. You've got that look — half hope, half panic. I can work with that.\"",
+        "\"Fresh blood. Literally, by the looks of it. Need something?\"",
+        "\"Early days, friend. Best stock up while you still have the gold for it.\"",
+        "\"You look new. Don't worry — everyone who walks in here looks new once.\""
+    };
+
+    /// <summary>Merchant greetings for floors 3-4 (mildly impressed).</summary>
+    public static readonly string[] GreetingsFloor3_4 =
+    {
+        "\"You've made it this far. Impressive.\"",
+        "\"Most don't reach this depth. You must be doing something right. Or lucky.\"",
+        "\"Still standing. Good. I prefer customers who can walk in on their own.\"",
+        "\"Mid-dungeon. Things get stranger from here. Best prepare now.\"",
+        "\"Floor three or four. You've earned a little respect. What do you need?\""
+    };
+
+    /// <summary>Merchant greetings for floors 5-6 (rare clientele).</summary>
+    public static readonly string[] GreetingsFloor5_6 =
+    {
+        "\"Not many customers reach this depth.\"",
+        "\"You're in rare company. Most of my clients stopped at floor two. Permanently.\"",
+        "\"The dungeon gets less forgiving from here. Let me help where I can.\"",
+        "\"You have the look of someone who's seen things. Good. It'll keep you sharp.\"",
+        "\"Floors five and six. Most folk only see these in their nightmares.\""
+    };
+
+    /// <summary>Merchant greetings for floors 7-8 (dark, ominous).</summary>
+    public static readonly string[] GreetingsFloor7_8 =
+    {
+        "\"Still alive? You must want something badly.\"",
+        "\"I didn't expect to see a customer. Not down this far. Not a living one.\"",
+        "\"The bottom of the dungeon. Whatever brought you here — I hope it was worth it.\"",
+        "\"You've outlived everyone who came before you this run. That's either skill or stubbornness.\"",
+        "\"Dark place for commerce. Then again, you're still here. So am I. We manage.\""
+    };
+
+    /// <summary>
+    /// Returns a random floor-appropriate merchant greeting based on the current floor.
+    /// </summary>
+    /// <param name="floor">The current dungeon floor (1-8).</param>
+    public static string GetFloorGreeting(int floor)
+    {
+        var pool = floor switch
+        {
+            <= 2 => GreetingsFloor1_2,
+            <= 4 => GreetingsFloor3_4,
+            <= 6 => GreetingsFloor5_6,
+            _    => GreetingsFloor7_8
+        };
+        return pool[_rng.Next(pool.Length)];
+    }
+
+    /// <summary>Returns a random line from <see cref="LegendarySold"/>.</summary>
+    public static string GetLegendarySold() => LegendarySold[_rng.Next(LegendarySold.Length)];
+    /// <summary>Returns a random line from <see cref="CantAfford"/>.</summary>
+    public static string GetCantAfford() => CantAfford[_rng.Next(CantAfford.Length)];
+    /// <summary>Returns a random line from <see cref="InventoryFull"/>.</summary>
+    public static string GetInventoryFull() => InventoryFull[_rng.Next(InventoryFull.Length)];
 }

--- a/Systems/ShrineNarration.cs
+++ b/Systems/ShrineNarration.cs
@@ -36,4 +36,52 @@ public static class ShrineNarration
         "Power moves through your bones like water through a crack. Old. Not entirely benign.",
         "You take what's offered and try not to think about who offered it."
     };
+    // Type-specific shrine blessing lines
+
+    /// <summary>Lines shown when a healing shrine fully restores the player's HP.</summary>
+    public static readonly string[] GrantHeal =
+    {
+        "The stone bleeds warmth. Your wounds close like they were never there.",
+        "Something old and merciful passes through you. The pain recedes.",
+        "The shrine's light seeps into your skin. You breathe easier.",
+        "Flesh knits. Blood stills. The shrine asks nothing in return. Nothing visible.",
+        "Whatever god this was built for — it was the merciful kind."
+    };
+
+    /// <summary>Lines shown when a power shrine blesses the player with ATK/DEF.</summary>
+    public static readonly string[] GrantPower =
+    {
+        "The runes flare. Your hands feel steadier. Your strike will be truer.",
+        "Something ancient sharpens inside you. A gift — or a debt.",
+        "The shrine's power settles into your bones. Quietly. Permanently.",
+        "You feel the difference immediately. Harder to hurt. Harder to miss.",
+        "Old prayers for old warriors. You aren't sure you're worthy. The shrine disagrees."
+    };
+
+    /// <summary>Lines shown when a protection shrine fortifies the player's MaxHP.</summary>
+    public static readonly string[] GrantProtection =
+    {
+        "Your chest expands. Something has decided you can take more.",
+        "The shrine reinforces you from within. Stone and faith, braided together.",
+        "You feel it in your ribs — a quiet, permanent refusal to fall.",
+        "Endurance, granted by something that has endured far longer than you.",
+        "The light wraps around you once, tight. Then fades. It left something behind."
+    };
+
+    /// <summary>Lines shown when a wisdom shrine expands the player's MaxMana.</summary>
+    public static readonly string[] GrantWisdom =
+    {
+        "The runes whisper in a language older than the dungeon. You understand it.",
+        "Your mind opens — just slightly, just enough. The magic flows deeper now.",
+        "Something vast reaches into your thoughts and makes room.",
+        "Knowledge, or the capacity for it. Either way, the well is deeper.",
+        "The shrine's light enters behind your eyes. The world looks slightly wider."
+    };
+
+    /// <summary>Lines shown when the player leaves the shrine without using it.</summary>
+    public static readonly string[] GrantNothing =
+    {
+        "The shrine watches you leave. It has waited this long.",
+        "Its light dims slightly as you turn away. Perhaps it was judging you. Perhaps not."
+    };
 }


### PR DESCRIPTION
Closes #454. Closes #455. Rebased onto master — resolves conflict with E1+E2 narration (whitespace-only CombatEngine conflict, no logic change). Contains: combat ambient wiring (start lines, crit flavor, kill-blow, near-death, boss charge), shrine type-specific narration, merchant greeting + reaction lines.