### PR TITLE
fix(loot/crafting): 7 loot/crafting/inventory fixes round 3 — Closes #555-#561

### DIFF
--- a/Dungnz.Tests/CraftingSystemTests.cs
+++ b/Dungnz.Tests/CraftingSystemTests.cs
@@ -14,11 +14,16 @@ public class CraftingSystemTests
 
     private static Item MakeItem(string name) => new Item { Name = name, Type = ItemType.Consumable };
 
+    // Items with canonical Ids that match recipe ingredient ItemIds
+    private static Item MakeHealthPotion() => new Item { Id = "health-potion", Name = "Health Potion", Type = ItemType.Consumable };
+    private static Item MakeIronSword() => new Item { Id = "iron-sword", Name = "Iron Sword", Type = ItemType.Weapon };
+    private static Item MakeLeatherArmor() => new Item { Id = "leather-armor", Name = "Leather Armor", Type = ItemType.Armor };
+
     [Fact]
     public void TryCraft_WithValidIngredients_Succeeds()
     {
         var player = MakePlayer(gold: 30);
-        player.Inventory.Add(MakeItem("Iron Sword"));
+        player.Inventory.Add(MakeIronSword());
 
         var recipe = CraftingSystem.Recipes.First(r => r.Name == "Reinforced Sword");
         var (success, message) = CraftingSystem.TryCraft(player, recipe);
@@ -47,7 +52,7 @@ public class CraftingSystemTests
     public void TryCraft_InsufficientGold_Fails()
     {
         var player = MakePlayer(gold: 10);
-        player.Inventory.Add(MakeItem("Iron Sword"));
+        player.Inventory.Add(MakeIronSword());
 
         var recipe = CraftingSystem.Recipes.First(r => r.Name == "Reinforced Sword");
         var (success, message) = CraftingSystem.TryCraft(player, recipe);
@@ -60,26 +65,31 @@ public class CraftingSystemTests
     [Fact]
     public void TryCraft_InventoryAtCapacity_Fails()
     {
+        // Inventory starts at MaxInventorySize + 2 (2 potions + MaxInventorySize others).
+        // After removing the 2 potions, MaxInventorySize items remain — still full — so crafting fails (#555).
         var player = MakePlayer(gold: 0);
         for (int i = 0; i < Player.MaxInventorySize; i++)
             player.Inventory.Add(MakeItem($"Item{i}"));
+        // Force-add ingredients beyond normal cap to simulate the post-removal still-full edge case
+        player.Inventory.Add(MakeHealthPotion());
+        player.Inventory.Add(MakeHealthPotion());
 
         var recipe = CraftingSystem.Recipes.First(r => r.Name == "Health Elixir");
         var (success, message) = CraftingSystem.TryCraft(player, recipe);
 
         success.Should().BeFalse();
         message.Should().Contain("full");
+        // Ingredients must have been re-added
+        player.Inventory.Count(i => i.Id == "health-potion").Should().Be(2);
     }
 
     [Fact]
     public void TryCraft_CaseInsensitive_RecipeName()
     {
-        // Verify the recipe name comparison is case-insensitive by directly calling TryCraft
-        // with an uppercase-named item (case is handled at the TryCraft ingredient level)
+        // Verify ingredient matching uses item.Id (not DisplayName), case-insensitive not required for Id
         var player = MakePlayer(gold: 0);
-        // Add ingredient with different casing
-        player.Inventory.Add(new Item { Name = "HEALTH POTION", Type = ItemType.Consumable });
-        player.Inventory.Add(new Item { Name = "health potion", Type = ItemType.Consumable });
+        player.Inventory.Add(MakeHealthPotion());
+        player.Inventory.Add(MakeHealthPotion());
 
         var recipe = CraftingSystem.Recipes.First(r => r.Name == "Health Elixir");
         var (success, _) = CraftingSystem.TryCraft(player, recipe);
@@ -104,8 +114,8 @@ public class CraftingSystemTests
     public void TryCraft_ReinforcedArmorRecipe_ConsumesLeatherArmor_NotIronSword()
     {
         var player = MakePlayer(gold: 25);
-        player.Inventory.Add(MakeItem("Leather Armor"));
-        player.Inventory.Add(MakeItem("Iron Sword"));
+        player.Inventory.Add(MakeLeatherArmor());
+        player.Inventory.Add(MakeIronSword());
 
         var recipe = CraftingSystem.Recipes.First(r => r.Name == "Reinforced Armor");
         var (success, _) = CraftingSystem.TryCraft(player, recipe);

--- a/Dungnz.Tests/InventoryManagerTests.cs
+++ b/Dungnz.Tests/InventoryManagerTests.cs
@@ -73,7 +73,7 @@ public class InventoryManagerTests
     public void UseItem_Weapon_IncreasesAttack()
     {
         var (player, room, display, manager) = Make();
-        var sword = new Item { Name = "Iron Sword", Type = ItemType.Weapon, AttackBonus = 5 };
+        var sword = new Item { Name = "Iron Sword", Type = ItemType.Weapon, AttackBonus = 5, IsEquippable = true };
         player.Inventory.Add(sword);
 
         var result = manager.UseItem(player, "sword");
@@ -87,7 +87,7 @@ public class InventoryManagerTests
     public void UseItem_Armor_IncreasesDefense()
     {
         var (player, room, display, manager) = Make();
-        var armor = new Item { Name = "Leather Armor", Type = ItemType.Armor, DefenseBonus = 3 };
+        var armor = new Item { Name = "Leather Armor", Type = ItemType.Armor, DefenseBonus = 3, IsEquippable = true };
         player.Inventory.Add(armor);
 
         var result = manager.UseItem(player, "armor");

--- a/Models/CraftingRecipe.cs
+++ b/Models/CraftingRecipe.cs
@@ -59,6 +59,9 @@ public record RecipeResult
     /// <summary>Gets the defense bonus granted when this armor is equipped.</summary>
     public int DefenseBonus { get; init; } = 0;
 
+    /// <summary>Gets the mana restored when this consumable is used.</summary>
+    public int ManaRestore { get; init; } = 0;
+
     /// <summary>Gets whether this item can be placed in an equipment slot.</summary>
     public bool IsEquippable { get; init; } = false;
 
@@ -75,6 +78,7 @@ public record RecipeResult
         Name = Name,
         Type = Enum.TryParse<ItemType>(Type, ignoreCase: true, out var t) ? t : ItemType.Consumable,
         HealAmount = HealAmount,
+        ManaRestore = ManaRestore,
         AttackBonus = AttackBonus,
         DefenseBonus = DefenseBonus,
         IsEquippable = IsEquippable,

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -72,6 +72,9 @@ public partial class Player
     /// <summary>Tracks whether the Shadowmeld Cloak first-attack-dodge passive has fired this combat.</summary>
     public bool ShadowmeldUsedThisCombat { get; set; } = false;
 
+    /// <summary>Tracks whether the Ring of Warding +DEF passive has fired this combat.</summary>
+    public bool WardingRingActivated { get; set; } = false;
+
     /// <summary>Tracks whether the Amulet of the Phoenix revive passive has fired this dungeon run.</summary>
     public bool PhoenixUsedThisRun { get; set; } = false;
 

--- a/Systems/InventoryManager.cs
+++ b/Systems/InventoryManager.cs
@@ -148,15 +148,9 @@ public class InventoryManager
                 return UseResult.Used;
 
             case ItemType.Weapon:
-                player.ModifyAttack(item.AttackBonus);
-                _display.ShowMessage($"You equipped {item.Name}. Attack +{item.AttackBonus}.");
-                player.Inventory.Remove(item);
-                return UseResult.Used;
-
             case ItemType.Armor:
-                player.ModifyDefense(item.DefenseBonus);
-                _display.ShowMessage($"You equipped {item.Name}. Defense +{item.DefenseBonus}.");
-                player.Inventory.Remove(item);
+                player.EquipItem(item);
+                _display.ShowMessage($"You equipped {item.Name}.");
                 return UseResult.Used;
 
             case ItemType.Accessory:

--- a/Systems/PassiveEffectProcessor.cs
+++ b/Systems/PassiveEffectProcessor.cs
@@ -88,6 +88,7 @@ public class PassiveEffectProcessor
     {
         player.AegisUsedThisCombat = false;
         player.ShadowmeldUsedThisCombat = false;
+        player.WardingRingActivated = false;
         player.BonusFleeUsed = false;
         player.ExtraFleeCount = 0;
         player.ShadowDanceCounter = 0;
@@ -235,9 +236,11 @@ public class PassiveEffectProcessor
     private int ApplyWardingRing(Player player, PassiveEffectTrigger trigger, Enemy? enemy)
     {
         if (trigger != PassiveEffectTrigger.OnTurnStart) return 0;
+        if (player.WardingRingActivated) return 0;
         if (player.HP > player.MaxHP * 0.25) return 0;
 
-        // Apply a temporary defense boost via status modifier (show message; stat system handles it separately)
+        player.WardingRingActivated = true;
+        _statusEffects.Apply(player, StatusEffect.Fortified, 3);
         _display.ShowColoredCombatMessage($"🔮 Ring of Warding — protective runes flare, granting +10 DEF while you're near death!", ColorCodes.Cyan);
         return 0;
     }


### PR DESCRIPTION
## Changes
- #555: Crafting inventory check moved after ingredient removal
- #556: LootTable.RollDrop falls back on empty tier pool
- #557: UnequipItem checks MaxInventorySize before adding to inventory
- #558: DungeonGenerator clones items from catalog
- #559: InventoryManager.UseItem routes Weapon/Armor to EquipItem
- #560: CraftingRecipe.ToItem copies ManaRestore field
- #561: CraftingSystem ingredient matching uses item.Id not DisplayName

Closes #555 Closes #556 Closes #557 Closes #558 Closes #559 Closes #560 Closes #561