### PR TITLE
fix(quality): Week 3 — Item.Clone propagation, boss TurnActions table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj/
 # Test result artifacts
 *.trx
 **/TestResults/
+coverage.opencover.xml

--- a/Dungnz.Tests/BossVariantTests.cs
+++ b/Dungnz.Tests/BossVariantTests.cs
@@ -80,4 +80,20 @@ public class BossVariantTests
 
         isTidalSlam.Should().BeFalse("TidalSlam requires !IsSubmerged");
     }
+
+    [Fact]
+    public void AbyssalLeviathan_TurnActions_ContainsTidalSlamOnInterval3()
+    {
+        var leviathan = new AbyssalLeviathan();
+        leviathan.TurnActions.Should().ContainKey(3);
+        leviathan.TurnActions[3].Should().Be("TidalSlam");
+    }
+
+    [Fact]
+    public void DungeonBoss_TurnActions_EmptyByDefault()
+    {
+        // Base class should have no turn actions unless a subclass adds them.
+        var boss = new DungeonBoss();
+        boss.TurnActions.Should().BeEmpty();
+    }
 }

--- a/Dungnz.Tests/RunStatsTests.cs
+++ b/Dungnz.Tests/RunStatsTests.cs
@@ -8,6 +8,7 @@ namespace Dungnz.Tests;
 /// Tests for RunStats accumulation — FloorsVisited, DamageTaken, and history recording.
 /// RunStats is a POCO; GameLoop writes to it directly, so we exercise it directly here.
 /// </summary>
+[Collection("RunStatsFileIO")] // serializes tests that write to stats-history.json
 public class RunStatsTests
 {
     [Fact]

--- a/Engine/CombatEngine.cs
+++ b/Engine/CombatEngine.cs
@@ -362,6 +362,16 @@ public class CombatEngine : ICombatEngine
                 }
             }
 
+            // Boss turn-action table dispatch (periodic turn-based abilities)
+            if (enemy is DungeonBoss bossTurn && bossTurn.TurnActions.Count > 0 && bossTurn.TurnCount > 0)
+            {
+                foreach (var (interval, abilityName) in bossTurn.TurnActions)
+                {
+                    if (bossTurn.TurnCount % interval == 0)
+                        ExecuteBossPhaseAbility(bossTurn, player, abilityName);
+                }
+            }
+
             if (enemy.HP <= 0)
             {
                 if (CheckOnDeathEffects(player, enemy, _rng)) continue; // enemy revived
@@ -1371,6 +1381,14 @@ public class CombatEngine : ICombatEngine
                     _display.ShowCombatMessage(ColorizeDamage($"A tentacle lashes you for {tentDmg} damage!", tentDmg));
                     if (player.HP <= 0) break;
                 }
+                break;
+
+            case "TidalSlam":
+                // AbyssalLeviathan: periodic 150% ATK slam + Slow (every 3rd turn from TurnActions table)
+                int slamDmg = Math.Max(1, (int)(boss.Attack * 1.5f) - player.Defense);
+                player.TakeDamage(slamDmg);
+                _statusEffects.Apply(player, StatusEffect.Slow, 2);
+                _display.ShowCombatMessage(ColorizeDamage($"⚡ The Leviathan erupts with a Tidal Slam! {slamDmg} damage + Slow!", slamDmg));
                 break;
 
             case "FlameBreath":

--- a/Engine/DungeonGenerator.cs
+++ b/Engine/DungeonGenerator.cs
@@ -258,7 +258,7 @@ public class DungeonGenerator
         {
             var pool = _allItems.Where(i => i.Tier == tier).ToList();
             if (pool.Count > 0)
-                return pool[_rng.Next(pool.Count)];
+                return pool[_rng.Next(pool.Count)].Clone();
         }
 
         // Fallback when item config not loaded

--- a/Systems/Enemies/BossVariants.cs
+++ b/Systems/Enemies/BossVariants.cs
@@ -238,7 +238,7 @@ public class AbyssalLeviathan : DungeonBoss
 {
     /// <summary>Parameterless constructor used by the JSON deserializer.</summary>
     [System.Text.Json.Serialization.JsonConstructor]
-    public AbyssalLeviathan() : base(null, null) { Name = "Abyssal Leviathan"; HP = MaxHP = 220; Attack = 48; Defense = 12; XPValue = 180; Phases.Add(new BossPhase(0.40, "TentacleBarrage")); }
+    public AbyssalLeviathan() : base(null, null) { Name = "Abyssal Leviathan"; HP = MaxHP = 220; Attack = 48; Defense = 12; XPValue = 180; Phases.Add(new BossPhase(0.40, "TentacleBarrage")); TurnActions[3] = "TidalSlam"; }
 
     /// <summary>Creates an AbyssalLeviathan with optional data-driven stats.</summary>
     public AbyssalLeviathan(EnemyStats? stats, List<ItemStats>? itemConfig) : base(stats, itemConfig)
@@ -246,6 +246,7 @@ public class AbyssalLeviathan : DungeonBoss
         Name = "Abyssal Leviathan";
         HP = MaxHP = 220; Attack = 48; Defense = 12; XPValue = 180;
         Phases.Add(new BossPhase(0.40, "TentacleBarrage"));
+        TurnActions[3] = "TidalSlam"; // every 3 turns
         AddLoot(itemConfig);
     }
 

--- a/Systems/Enemies/DungeonBoss.cs
+++ b/Systems/Enemies/DungeonBoss.cs
@@ -46,6 +46,12 @@ public class DungeonBoss : Enemy
     /// <summary>Tracks which phase ability names have already fired this combat, preventing duplicate triggers.</summary>
     public HashSet<string> FiredPhases { get; } = new();
 
+    /// <summary>
+    /// Periodic turn-based abilities. Key = turn interval (fires when <c>TurnCount % key == 0</c>),
+    /// value = ability name passed to <see cref="Engine.CombatEngine.ExecuteBossPhaseAbility"/>.
+    /// </summary>
+    public Dictionary<int, string> TurnActions { get; } = new();
+
     private readonly int _baseAttack;
 
     /// <summary>

--- a/Systems/MerchantInventoryConfig.cs
+++ b/Systems/MerchantInventoryConfig.cs
@@ -98,7 +98,7 @@ public static class MerchantInventoryConfig
         foreach (var id in config.Guaranteed)
         {
             if (byId.TryGetValue(id, out var item))
-                stock.Add(new MerchantItem { Item = item, Price = ComputePrice(item) });
+                stock.Add(new MerchantItem { Item = item.Clone(), Price = ComputePrice(item) });
         }
 
         // Fill remaining slots from pool (exclude already-stocked IDs)
@@ -112,7 +112,7 @@ public static class MerchantInventoryConfig
         foreach (var id in available.Take(remaining))
         {
             if (byId.TryGetValue(id, out var item))
-                stock.Add(new MerchantItem { Item = item, Price = ComputePrice(item) });
+                stock.Add(new MerchantItem { Item = item.Clone(), Price = ComputePrice(item) });
         }
 
         return stock;


### PR DESCRIPTION
## Summary

Week 3 quality improvements.

### Changes

**Engine/DungeonGenerator.cs**
- `CreateRandomItem()` now returns `item.Clone()` — each dungeon room gets an independent item instance, preventing mutations from one room affecting another

**Systems/MerchantInventoryConfig.cs**
- Merchant stock items now use `item.Clone()` for both guaranteed and pool items

**Systems/Enemies/DungeonBoss.cs**
- Added `Dictionary<int, string> TurnActions` — maps turn interval → ability name for data-driven periodic boss abilities

**Engine/CombatEngine.cs**
- Wired `TurnActions` dispatch in combat loop: fires abilities from the table when `TurnCount % interval == 0`
- Added `case "TidalSlam"` to `ExecuteBossPhaseAbility` switch (150% ATK slam + Slow 2T)

**Systems/Enemies/BossVariants.cs**
- `AbyssalLeviathan` populates `TurnActions[3] = "TidalSlam"` in both constructors

**Dungnz.Tests/BossVariantTests.cs**
- Tests for `TurnActions` table setup on `AbyssalLeviathan` and empty default on base `DungeonBoss`

**Dungnz.Tests/RunStatsTests.cs**
- Added `[Collection("RunStatsFileIO")]` to serialize file-IO tests and prevent parallel interference

### Test results
673/673 passing ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>