### PR TITLE
feat(quality): Week 3 tests — CsCheck property tests + Stryker workflow

### DIFF
--- a/.github/workflows/squad-stryker.yml
+++ b/.github/workflows/squad-stryker.yml
@@ -1,0 +1,50 @@
+name: Stryker Mutation Testing
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # Every Monday at 03:00 UTC
+  workflow_dispatch:      # Allow manual runs
+
+jobs:
+  mutation-test:
+    name: Stryker.NET mutation score
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Install Stryker.NET
+        run: dotnet tool install --global dotnet-stryker
+
+      - name: Run Stryker mutation tests
+        run: |
+          dotnet stryker \
+            --project Dungnz.csproj \
+            --test-project Dungnz.Tests/Dungnz.Tests.csproj \
+            --threshold-break 50 \
+            --threshold-low 65 \
+            --threshold-high 80 \
+            --reporter "html" \
+            --reporter "progress" \
+            --output StrykerOutput \
+            --mutate "Engine/**/*.cs" \
+            --mutate "Systems/**/*.cs" \
+            --mutate "Models/**/*.cs"
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stryker-mutation-report
+          path: StrykerOutput/
+          retention-days: 30

--- a/Dungnz.Tests/Dungnz.Tests.csproj
+++ b/Dungnz.Tests/Dungnz.Tests.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="CsCheck" Version="3.8.3" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/Dungnz.Tests/PropertyTests.cs
+++ b/Dungnz.Tests/PropertyTests.cs
@@ -1,0 +1,86 @@
+using CsCheck;
+using Dungnz.Models;
+using Dungnz.Systems;
+using FluentAssertions;
+using Xunit;
+
+namespace Dungnz.Tests;
+
+/// <summary>
+/// Property-based tests using CsCheck to verify invariants that must hold for all
+/// generated inputs — LootTable RNG determinism, Item.Clone isolation, and
+/// Player stat non-negativity after equip/unequip cycles.
+/// </summary>
+public class PropertyTests
+{
+    // ── LootTable: two tables seeded identically produce identical gold rolls ──
+
+    [Fact]
+    public void LootTable_IdenticalSeeds_ProduceIdenticalGoldRolls()
+    {
+        Gen.Int[1, 9999].Sample(seed =>
+        {
+            var table1 = new LootTable(new Random(seed), minGold: 1, maxGold: 50);
+            var table2 = new LootTable(new Random(seed), minGold: 1, maxGold: 50);
+
+            var dummy = new Dungnz.Systems.Enemies.GiantRat();
+            var result1 = table1.RollDrop(dummy);
+            var result2 = table2.RollDrop(dummy);
+
+            result1.Gold.Should().Be(result2.Gold,
+                $"identical seed {seed} must yield identical gold rolls");
+        });
+    }
+
+    // ── Item.Clone: clone is independent of source ────────────────────────
+
+    [Fact]
+    public void Item_Clone_IsIndependent()
+    {
+        Gen.Int[0, 50].Select(Gen.Int[0, 50]).Sample((atk, def) =>
+        {
+            var original = new Item
+            {
+                Name = "Test Sword",
+                Type = ItemType.Weapon,
+                AttackBonus = atk,
+                DefenseBonus = def,
+                IsEquippable = true,
+                Tier = ItemTier.Common
+            };
+            var clone = original.Clone();
+
+            // Mutate original — clone should not be affected
+            original.AttackBonus = 999;
+
+            clone.AttackBonus.Should().Be(atk,
+                $"Clone should be independent: original.AttackBonus mutated to 999 but clone should remain {atk}");
+        });
+    }
+
+    // ── Player defense never goes below zero after equip/unequip ─────────
+
+    [Fact]
+    public void Player_Defense_NeverNegativeAfterUnequip()
+    {
+        Gen.Int[0, 20].Sample(defBonus =>
+        {
+            var player = new Player { HP = 100, MaxHP = 100, Attack = 10, Defense = 5, Level = 1 };
+            var armor = new Item
+            {
+                Name = "Test Armor",
+                Type = ItemType.Armor,
+                DefenseBonus = defBonus,
+                IsEquippable = true,
+                Tier = ItemTier.Common,
+                Slot = ArmorSlot.Chest
+            };
+            player.Inventory.Add(armor);
+            player.EquipItem(armor);
+            player.UnequipItem("chest");
+
+            player.Defense.Should().BeGreaterThanOrEqualTo(0,
+                $"Defense must not go negative after equipping then unequipping +{defBonus} DEF armor");
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Completes Week 3 of the quality improvement plan.

### Changes

**Dungnz.Tests/PropertyTests.cs** (new)
- `LootTable_IdenticalSeeds_ProduceIdenticalGoldRolls` — property: same seed always produces same gold roll
- `Item_Clone_IsIndependent` — property: mutating original after clone never affects clone stats
- `Player_Defense_NeverNegativeAfterUnequip` — property: defense stays ≥0 for any valid armor bonus

Uses CsCheck 3.8.3 for shrinking and deterministic replay on failure.

**.github/workflows/squad-stryker.yml** (new)
- Weekly Stryker.NET mutation testing (Mondays 03:00 UTC + manual dispatch)
- Targets Engine/, Systems/, Models/ source files
- Thresholds: break=50%, low=65%, high=80%
- Uploads HTML mutation report as 30-day artifact

### Test results
678/678 passing ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>