### PR TITLE
fix: SELL typed inside merchant shop now opens sell menu (#574, #575)

### DIFF
--- a/Dungnz.Tests/SellSystemTests.cs
+++ b/Dungnz.Tests/SellSystemTests.cs
@@ -220,6 +220,26 @@ public class SellSystemTests
     }
 
     // ────────────────────────────────────────────────────────────────────────
+    // Regression: #574 — typing SELL inside the shop must open sell menu, not exit shop
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Regression574_Sell_TypedInsideShop_OpensSellerNotExitShop()
+    {
+        // Sequence: open shop with SHOP, type SELL inside shop, pick item 1, confirm Y, exit shop with X
+        var (player, room, display, loop) = MakeSellSetup("shop", "sell", "1", "Y", "x", "quit");
+        var potion = new Item { Name = "Health Potion", Type = ItemType.Consumable, Tier = ItemTier.Common };
+        player.Inventory.Add(potion);
+
+        int expectedPrice = MerchantInventoryConfig.ComputeSellPrice(potion);
+
+        loop.Run(player, room);
+
+        player.Inventory.Should().NotContain(potion, "item should have been sold via SELL typed inside the shop");
+        player.Gold.Should().Be(expectedPrice, "gold should be awarded after selling from inside the shop");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
     // 6. Cancel sell
     // ────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Fixes
Closes #574 — game-breaking: typing SELL inside shop exited instead of opening sell menu  
Closes #575 — UX: room entry didn't mention SELL command

## Changes

### Engine/GameLoop.cs
- `HandleShop()` now loops (player can sell then buy, or exit with X)
- Added `else if input == "sell"` branch that calls `HandleSell()` directly  
- After sell completes, shop re-displays so player can continue shopping
- Updated room entry merchant notification: *"Type SHOP to browse, or SELL to sell items"*

### Dungnz.Tests/SellSystemTests.cs
- Added `Regression574_Sell_TypedInsideShop_OpensSellerNotExitShop`: verifies shop → SELL inside shop → item sold, gold awarded

## Test Results
679/679 passing (1 new test)