### PR TITLE
fix(sell): sell-to-merchant crash fix + sell equipped items

### DIFF
--- a/Dungnz.Tests/SellSystemTests.cs
+++ b/Dungnz.Tests/SellSystemTests.cs
@@ -163,18 +163,22 @@ public class SellSystemTests
     }
 
     [Fact]
-    public void Sell_OnlyEquippedWeapon_NoInventoryItems_ShowsNoSellNarration()
+    public void Sell_OnlyEquippedWeapon_NoInventoryItems_ShowsSellMenuWithEquippedItem()
     {
-        // Only equipped weapon — Inventory is empty → a "NoSell" narration line is shown
-        var (player, room, display, loop) = MakeSellSetup("sell", "quit");
+        // Only equipped weapon — with BuildSellableList, equipped items ARE included in sell menu.
+        // Input: "sell" → shows sell menu, "x" → cancel, "quit" → exit
+        var (player, room, display, loop) = MakeSellSetup("sell", "x", "quit");
 
         var sword = new Item { Name = "Iron Sword", Type = ItemType.Weapon, Tier = ItemTier.Common, IsEquippable = true };
         player.EquippedWeapon = sword;
 
         loop.Run(player, room);
 
-        display.Messages.Should().Contain(m => MerchantNarration.NoSell.Contains(m),
-            "a no-sell narration line should be shown when inventory has nothing sellable");
+        // Sell menu should be shown containing the equipped weapon
+        display.AllOutput.Should().Contain(m => m.StartsWith("sell:"),
+            "the sell menu should appear because BuildSellableList includes equipped items");
+        player.EquippedWeapon.Should().Be(sword, "weapon should remain equipped after cancelling");
+        player.Gold.Should().Be(0, "no gold should be awarded on cancel");
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/Models/PlayerCombat.cs
+++ b/Models/PlayerCombat.cs
@@ -302,7 +302,7 @@ public partial class Player
         RecalculateDerivedBonuses();
     }
 
-    private void RecalculateDerivedBonuses()
+    internal void RecalculateDerivedBonuses()
     {
         DodgeBonus = (EquippedWeapon?.DodgeBonus ?? 0f)
                    + (EquippedAccessory?.DodgeBonus ?? 0f)


### PR DESCRIPTION
## Summary

Fixes #577 — game-breaking sell-to-merchant bug caused by a compilation error.

## Root Cause

`UnequipItemFromSlot()` called `_player.RecalculateDerivedStats()` which doesn't exist. Correct method is `RecalculateDerivedBonuses()` in `Models/PlayerCombat.cs`.

## Changes

- **Engine/GameLoop.cs**: `HandleSell()` now uses `BuildSellableList()` returning both inventory AND equipped items as `List<(Item Item, bool IsEquipped)>`. Added `BuildSellableList()` and `UnequipItemFromSlot()` private methods. Fixed method call.
- **Models/PlayerCombat.cs**: `RecalculateDerivedBonuses()` changed from `private` → `internal` to allow cross-class call within same assembly.
- **Dungnz.Tests/SellSystemTests.cs**: Updated test that expected equipped weapon to show 'nothing to sell' — it now correctly shows the sell menu.

## Testing

All 12 sell system tests pass. 679 total tests passing.

Closes #577