### PR TITLE
ci: add master to pull_request trigger branches

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -2,7 +2,7 @@ name: Squad CI
 
 on:
   pull_request:
-    branches: [dev, preview, main]
+    branches: [dev, preview, main, master]
     types: [opened, synchronize, reopened]
   push:
     branches: [dev, preview, main, master]


### PR DESCRIPTION
PR #579 targets master but the pull_request trigger only included dev/preview/main, so CI never ran. Adding master unblocks the PR.