### PR TITLE
fix: correct ANSI cursor-up off-by-one in menu rendering

### DIFF
--- a/Display/ConsoleMenuNavigator.cs
+++ b/Display/ConsoleMenuNavigator.cs
@@ -35,10 +35,12 @@ public sealed class ConsoleMenuNavigator : IMenuNavigator
             switch (key.Key)
             {
                 case ConsoleKey.UpArrow:
-                    if (selected > 0) { selected--; RenderOptions(options, selected, ref firstRender); }
+                    selected = (selected - 1 + options.Count) % options.Count;
+                    RenderOptions(options, selected, ref firstRender);
                     break;
                 case ConsoleKey.DownArrow:
-                    if (selected < options.Count - 1) { selected++; RenderOptions(options, selected, ref firstRender); }
+                    selected = (selected + 1) % options.Count;
+                    RenderOptions(options, selected, ref firstRender);
                     break;
                 case ConsoleKey.Enter:
                     Console.WriteLine();
@@ -64,7 +66,7 @@ public sealed class ConsoleMenuNavigator : IMenuNavigator
         // Move cursor up to start of menu using ANSI relative positioning
         // (avoids stale absolute row when terminal scrolls or lines wrap)
         if (!firstRender)
-            Console.Write($"\x1b[{options.Count}A");
+            Console.Write($"\x1b[{options.Count - 1}A");
         firstRender = false;
 
         for (int i = 0; i < options.Count; i++)

--- a/Display/DisplayService.cs
+++ b/Display/DisplayService.cs
@@ -11,6 +11,7 @@ namespace Dungnz.Display;
 public class ConsoleDisplayService : IDisplayService
 {
     private readonly IInputReader _input;
+    // TODO: wire up navigator call-sites (issue #586)
     private readonly IMenuNavigator _navigator;
 
     /// <summary>Initialises the display service with the given input and menu navigator.</summary>
@@ -621,7 +622,7 @@ public class ConsoleDisplayService : IDisplayService
             // Move cursor up to start of menu using ANSI relative positioning
             // (avoids stale absolute row when terminal scrolls or lines wrap)
             if (!firstRender)
-                Console.Write($"\x1b[{options.Count}A");
+                Console.Write($"\x1b[{options.Count - 1}A");
             firstRender = false;
 
             for (int i = 0; i < options.Count; i++)

--- a/Dungnz.Tests/CombatBalanceSimulationTests.cs
+++ b/Dungnz.Tests/CombatBalanceSimulationTests.cs
@@ -274,4 +274,5 @@ internal sealed class AlwaysAttackInputReader : IInputReader
 {
     public string? ReadLine() => "A";
     public ConsoleKeyInfo? ReadKey() => null;
+    public bool IsInteractive => false;
 }


### PR DESCRIPTION
Fixes #584, #585, #587. Defers #586 with TODO comment.

## Changes
- **DisplayService.cs**: Fix off-by-one in `SelectFromMenu<T>` cursor-up escape (N → N-1). Resolves the Ranger regression.
- **ConsoleMenuNavigator.cs**: Fix same off-by-one in `RenderOptions`. Fix wrap vs clamp inconsistency in `Select`.
- Add TODO comment for #586 (ConsoleMenuNavigator dead code — deferred)

## Testing
683/684 tests pass (1 pre-existing failure in RunStatsTests unrelated to these changes). The interactive ANSI path is only exercised manually (TTY required), but the logic change is straightforward: cursor must move up N-1 lines when N items are rendered (the last item has no trailing newline).