### PR TITLE
fix: class icon consistency and loot card border alignment

### DIFF
--- a/Display/DisplayService.cs
+++ b/Display/DisplayService.cs
@@ -301,7 +301,7 @@ public class ConsoleDisplayService : IDisplayService
     {
         var icon = ItemTypeIcon(item.Type);
         var stat = PrimaryStatLabel(item);
-        var namePad = new string(' ', Math.Max(0, 34 - (TruncateName(item.Name).Length)));
+        var namePad = new string(' ', Math.Max(0, 35 - icon.Length - TruncateName(item.Name).Length));
         var header = isElite ? $"✦ {Systems.ColorCodes.Yellow}ELITE LOOT DROP{Systems.ColorCodes.Reset}" : "✦ LOOT DROP";
         var tierLabel = item.Tier switch
         {
@@ -1172,7 +1172,7 @@ public class ConsoleDisplayService : IDisplayService
         const int baseMana = 30;
 
         var classes = new[] {
-            (def: PlayerClassDefinition.Warrior,    icon: "⚔",  number: 1, iconWidth: 1),
+            (def: PlayerClassDefinition.Warrior,    icon: "⚔",  number: 1, iconWidth: 2),
             (def: PlayerClassDefinition.Mage,       icon: "🔮", number: 2, iconWidth: 2),
             (def: PlayerClassDefinition.Rogue,       icon: "🗡",  number: 3, iconWidth: 2),
             (def: PlayerClassDefinition.Paladin,    icon: "🛡",  number: 4, iconWidth: 2),
@@ -1256,9 +1256,9 @@ public class ConsoleDisplayService : IDisplayService
 
         var selectOptions = new (string Label, PlayerClassDefinition Value)[]
         {
-            ("⚔  Warrior",     PlayerClassDefinition.Warrior),
+            ("⚔ Warrior",      PlayerClassDefinition.Warrior),
             ("🔮 Mage",         PlayerClassDefinition.Mage),
-            ("🗡  Rogue",        PlayerClassDefinition.Rogue),
+            ("🗡 Rogue",         PlayerClassDefinition.Rogue),
             ("🛡 Paladin",      PlayerClassDefinition.Paladin),
             ("💀 Necromancer",  PlayerClassDefinition.Necromancer),
             ("🏹 Ranger",       PlayerClassDefinition.Ranger),


### PR DESCRIPTION
Fixes #589, #590, #593.

## Changes
- **Warrior iconWidth** in stat cards: 1→2 (consistent with all other classes)
- **Warrior select label**: removed extra space after ⚔ icon (1 space like others)
- **Rogue select label**: removed extra space after 🗡 icon (fixes visual indentation)
- **ShowLootDrop namePad**: now accounts for icon.Length → fixes right-border misalignment for Armor/Consumable/Accessory loot cards

## Root causes
- ⚔ (U+2694, Weapon icon) is a BMP char with C# Length=1; all other item icons are supplementary-plane emoji with Length=2. The static namePad formula only worked for Length=1.
- Warrior and Rogue class labels had copy-paste extra spaces causing visual inconsistency.

## Testing
683/684 tests passing (1 pre-existing flaky unrelated to these changes).