### PR TITLE
fix: repair CI YAML heredoc indentation (fixes all workflow runs)

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -81,29 +81,29 @@ jobs:
         run: |
           pip install jsonschema --quiet
           python3 - << 'PYEOF'
-import json, jsonschema, sys
+          import json, jsonschema, sys
 
-pairs = [
-    ("Data/item-stats.json",        "Data/schemas/item-stats.schema.json"),
-    ("Data/enemy-stats.json",       "Data/schemas/enemy-stats.schema.json"),
-    ("Data/crafting-recipes.json",  "Data/schemas/crafting-recipes.schema.json"),
-    ("Data/item-affixes.json",      "Data/schemas/item-affixes.schema.json"),
-]
+          pairs = [
+              ("Data/item-stats.json",        "Data/schemas/item-stats.schema.json"),
+              ("Data/enemy-stats.json",       "Data/schemas/enemy-stats.schema.json"),
+              ("Data/crafting-recipes.json",  "Data/schemas/crafting-recipes.schema.json"),
+              ("Data/item-affixes.json",      "Data/schemas/item-affixes.schema.json"),
+          ]
 
-errors = []
-for data_path, schema_path in pairs:
-    with open(data_path) as f:
-        data = json.load(f)
-    with open(schema_path) as f:
-        schema = json.load(f)
-    try:
-        jsonschema.validate(data, schema)
-        print(f"✅ {data_path}")
-    except jsonschema.ValidationError as e:
-        errors.append(f"❌ {data_path}: {e.message}")
-        print(f"❌ {data_path}: {e.message}")
+          errors = []
+          for data_path, schema_path in pairs:
+              with open(data_path) as f:
+                  data = json.load(f)
+              with open(schema_path) as f:
+                  schema = json.load(f)
+              try:
+                  jsonschema.validate(data, schema)
+                  print(f"✅ {data_path}")
+              except jsonschema.ValidationError as e:
+                  errors.append(f"❌ {data_path}: {e.message}")
+                  print(f"❌ {data_path}: {e.message}")
 
-if errors:
-    print(f"\n::error::JSON schema validation failed for {len(errors)} file(s).")
-    sys.exit(1)
-PYEOF
+          if errors:
+              print(f"\n::error::JSON schema validation failed for {len(errors)} file(s).")
+              sys.exit(1)
+          PYEOF


### PR DESCRIPTION
## Problem

Every GitHub Actions run was completing instantly with 0 jobs and `conclusion: failure`. No logs existed because no jobs ever started.

## Root Cause

The Python heredoc content inside the `Validate JSON data files against schemas` step was indented at column 0 inside a `run: |` YAML block scalar. The block scalar's content indentation level was established at 10 spaces (by `pip install jsonschema --quiet`). When YAML encountered the unindented Python code at column 0, it exited the block scalar prematurely — making the entire workflow structurally invalid. GitHub Actions rejected every run before scheduling any jobs.

## Fix

Indent the heredoc body and `PYEOF` terminator to 10 spaces (matching the rest of the `run:` block). YAML strips the common 10-space prefix before the script reaches bash, so bash receives clean column-0 Python and recognises `PYEOF` as the heredoc terminator correctly.

## Verification

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/squad-ci.yml').read()); print('YAML valid')"
# → YAML valid ✅
```

Closes #none (infrastructure fix)