### PR TITLE
feat: Migrate ability menu to arrow-key navigation

### DIFF
--- a/Dungnz.Tests/Helpers/FakeDisplayService.cs
+++ b/Dungnz.Tests/Helpers/FakeDisplayService.cs
@@ -145,7 +145,16 @@ public class FakeDisplayService : IDisplayService
     public int ShowContestedArmoryMenuAndSelect(int playerDefense) { AllOutput.Add("armory_menu"); return 0; }
     public Ability? ShowAbilityMenuAndSelect(IEnumerable<(Ability ability, bool onCooldown, int cooldownTurns, bool notEnoughMana)> unavailableAbilities, IEnumerable<Ability> availableAbilities) 
     { 
-        AllOutput.Add("ability_menu"); 
+        AllOutput.Add("ability_menu");
+        if (_input is not null)
+        {
+            var available = availableAbilities.ToList();
+            var line = _input.ReadLine()?.Trim() ?? "";
+            if (line.Equals("C", StringComparison.OrdinalIgnoreCase) || line.Equals("CANCEL", StringComparison.OrdinalIgnoreCase))
+                return null;
+            if (int.TryParse(line, out int idx) && idx >= 1 && idx <= available.Count)
+                return available[idx - 1];
+        }
         return null; 
     }
     


### PR DESCRIPTION
Closes #640

Migrates the ability selection menu in CombatEngine to the SelectFromMenu arrow-key pattern.

- Unavailable abilities (cooldown/mana) shown as informational lines above the menu
- Only usable abilities appear as selectable options, plus Cancel
- FakeDisplayService.ShowAbilityMenuAndSelect reads input to preserve test compatibility
- No combat logic changes — UI layer only
- Fix #611 (cancel path calls PerformEnemyTurn) preserved