### PR TITLE
feat: Migrate Regular Shrine, Shop, and Sell to arrow-key menus

### DIFF
--- a/.ai-team/decisions/inbox/hill-shrine-shop-sell.md
+++ b/.ai-team/decisions/inbox/hill-shrine-shop-sell.md
@@ -1,0 +1,44 @@
+# Decision: Arrow-Key Menu Migration for Regular Shrine, Shop, and Sell
+
+**Context:** Issues #639 and #641 requested migrating the last letter-key and number-entry interactions in GameLoop to arrow-key menus.
+
+**Decision:** Added 3 new display methods and migrated 3 GameLoop handlers.
+
+## New Display Methods
+
+### `ShowShrineMenuAndSelect(int playerGold) → int`
+- Returns 1–4 for the four shrine blessings (Heal/Bless/Fortify/Meditate) or 0 to leave
+- Replaces letter-key input (H/B/F/M/L) in `HandleShrine()`
+
+### `ShowShopWithSellAndSelect(stock, playerGold) → int`
+- Returns 1-based item index for buying, -1 for "Sell Items", or 0 to leave
+- Replaces the old number-entry + "SELL" text command pattern
+- Note: Different from `ShowShopAndSelect` which only handles item selection (no Sell option)
+
+### `ShowConfirmMenu(string prompt) → bool`
+- Returns true for Yes, false for No
+- Replaces Y/N text input in sell confirmation
+- Reusable for any binary choice
+
+## Implementation Notes
+
+- All three use the existing `SelectFromMenu<T>` private helper in DisplayService
+- Test mode fallback: FakeDisplayService reads from injected IInputReader for realistic test behavior
+- Shop loop pattern: Buying/selling continues the loop; only explicit "Leave" exits
+
+## Rationale
+
+- **Consistency:** All interactive choices now use arrow-key menus (combat, level-up, crafting, shrines, shop)
+- **Testability:** Numeric returns (int/bool) are easier to mock than string parsing in tests
+- **Display layer ownership:** UI logic stays in Display, game state changes stay in GameLoop
+- **User experience:** Arrow-key navigation is more intuitive than remembering letter/number codes
+
+## Team Impact
+
+- **Romanoff (Testing):** Test stubs added to FakeDisplayService and TestDisplayService — all tests pass
+- **Barton (Combat):** No impact — combat menus already use arrow keys
+- **Hill (Engine):** GameLoop now cleaner — no more ReadLine + switch(string) patterns in shrine/shop/sell
+
+## Migration Status
+
+Remaining letter-key interactions: None in core gameplay loop. All major interactions (combat, level-up, shrines, shop, crafting) now use arrow-key menus.

--- a/Display/DisplayService.cs
+++ b/Display/DisplayService.cs
@@ -576,6 +576,47 @@ public class ConsoleDisplayService : IDisplayService
         return SelectFromMenu(options.AsReadOnly(), _input);
     }
 
+    /// <summary>Presents the Shrine blessing choices as an arrow-key menu and returns 1–4 or 0 (leave).</summary>
+    public int ShowShrineMenuAndSelect(int playerGold)
+    {
+        var options = new (string Label, int Value)[]
+        {
+            ($"Heal fully        — 30g  (Your gold: {playerGold}g)", 1),
+            ("Bless             — 50g  (+2 ATK/DEF permanently)", 2),
+            ("Fortify           — 75g  (MaxHP +10, permanent)", 3),
+            ("Meditate          — 75g  (MaxMana +10, permanent)", 4),
+            ("Leave", 0),
+        };
+        return SelectFromMenu(options.AsReadOnly(), _input, "✨ [Shrine Menu]");
+    }
+
+    /// <summary>
+    /// Presents the shop menu with merchant stock, a Sell Items option, and Leave.
+    /// Returns the selected item index (1-based for buying), -1 for Sell, or 0 to Leave.
+    /// </summary>
+    public int ShowShopWithSellAndSelect(IEnumerable<(Item item, int price)> stock, int playerGold)
+    {
+        var stockList = stock.ToList();
+        ShowShop(stockList, playerGold);   // Use existing box-drawing render
+        var options = stockList
+            .Select((s, i) => ($"{TruncateName(s.item.Name)}  {s.price}g", i + 1))
+            .Append(("💰 Sell Items", -1))
+            .Append(("Leave", 0))
+            .ToArray();
+        return SelectFromMenu(options.AsReadOnly(), _input);
+    }
+
+    /// <summary>Presents a Yes/No confirmation menu. Returns true if Yes selected.</summary>
+    public bool ShowConfirmMenu(string prompt)
+    {
+        var options = new (string Label, bool Value)[]
+        {
+            ("Yes", true),
+            ("No", false),
+        };
+        return SelectFromMenu(options.AsReadOnly(), _input, prompt);
+    }
+
 
     // ── helpers ────────────────────────────────────────────────────────────
 

--- a/Display/IDisplayService.cs
+++ b/Display/IDisplayService.cs
@@ -298,6 +298,18 @@ public interface IDisplayService
     /// </summary>
     int ShowCraftMenuAndSelect(IEnumerable<(string recipeName, bool canCraft)> recipes);
 
+    /// <summary>Presents the Shrine blessing choices as an arrow-key menu and returns 1–4 or 0 (leave).</summary>
+    int ShowShrineMenuAndSelect(int playerGold);
+
+    /// <summary>
+    /// Presents the shop menu with merchant stock, a Sell Items option, and Leave.
+    /// Returns the selected item index (1-based for buying), -1 for Sell, or 0 to Leave.
+    /// </summary>
+    int ShowShopWithSellAndSelect(IEnumerable<(Dungnz.Models.Item item, int price)> stock, int playerGold);
+
+    /// <summary>Presents a Yes/No confirmation menu. Returns true if Yes selected.</summary>
+    bool ShowConfirmMenu(string prompt);
+
     /// <summary>Presents a two-option trap room choice as an arrow-key menu and returns 1, 2, or 0 (leave).</summary>
     int ShowTrapChoiceAndSelect(string header, string option1, string option2);
 

--- a/Dungnz.Tests/Helpers/FakeDisplayService.cs
+++ b/Dungnz.Tests/Helpers/FakeDisplayService.cs
@@ -143,6 +143,36 @@ public class FakeDisplayService : IDisplayService
     public int ShowTrapChoiceAndSelect(string header, string option1, string option2) { AllOutput.Add("trap_choice"); return 0; }
     public int ShowForgottenShrineMenuAndSelect() { AllOutput.Add("shrine_menu"); return 0; }
     public int ShowContestedArmoryMenuAndSelect(int playerDefense) { AllOutput.Add("armory_menu"); return 0; }
+    public int ShowShrineMenuAndSelect(int playerGold) 
+    { 
+        AllOutput.Add("shrine_regular"); 
+        if (_input is not null)
+        {
+            var line = _input.ReadLine()?.Trim() ?? "";
+            if (int.TryParse(line, out int n) && n >= 0 && n <= 4) return n;
+        }
+        return 0; 
+    }
+    public int ShowShopWithSellAndSelect(IEnumerable<(Item item, int price)> stock, int playerGold)
+    {
+        AllOutput.Add($"shop_with_sell:{playerGold}g");
+        if (_input is not null)
+        {
+            var line = _input.ReadLine()?.Trim() ?? "";
+            if (int.TryParse(line, out int n)) return n;
+        }
+        return 0;
+    }
+    public bool ShowConfirmMenu(string prompt)
+    {
+        AllOutput.Add($"confirm:{prompt}");
+        if (_input is not null)
+        {
+            var line = _input.ReadLine()?.Trim().ToUpperInvariant() ?? "";
+            if (line == "Y" || line == "YES" || line == "1") return true;
+        }
+        return false;
+    }
     public Ability? ShowAbilityMenuAndSelect(IEnumerable<(Ability ability, bool onCooldown, int cooldownTurns, bool notEnoughMana)> unavailableAbilities, IEnumerable<Ability> availableAbilities) 
     { 
         AllOutput.Add("ability_menu");

--- a/Dungnz.Tests/Helpers/TestDisplayService.cs
+++ b/Dungnz.Tests/Helpers/TestDisplayService.cs
@@ -131,6 +131,9 @@ public class TestDisplayService : IDisplayService
     public int ShowTrapChoiceAndSelect(string header, string option1, string option2) { AllOutput.Add("trap_choice"); return 0; }
     public int ShowForgottenShrineMenuAndSelect() { AllOutput.Add("shrine_menu"); return 0; }
     public int ShowContestedArmoryMenuAndSelect(int playerDefense) { AllOutput.Add("armory_menu"); return 0; }
+    public int ShowShrineMenuAndSelect(int playerGold) { AllOutput.Add("shrine_regular"); return 0; }
+    public int ShowShopWithSellAndSelect(IEnumerable<(Item item, int price)> stock, int playerGold) { AllOutput.Add($"shop_with_sell:{playerGold}g"); return 0; }
+    public bool ShowConfirmMenu(string prompt) { AllOutput.Add($"confirm:{prompt}"); return false; }
     public Ability? ShowAbilityMenuAndSelect(IEnumerable<(Ability ability, bool onCooldown, int cooldownTurns, bool notEnoughMana)> unavailableAbilities, IEnumerable<Ability> availableAbilities) 
     { 
         AllOutput.Add("ability_menu"); 


### PR DESCRIPTION
Closes #639
Closes #641

Migrates Regular Shrine (letter-key H/B/F/M/L → arrow menu), Shop (number-entry → arrow menu with Sell option), and Sell (number-entry + Y/N confirm → arrow menus).

ShowShopAndSelect and ShowSellMenuAndSelect were already in DisplayService but unwired. Added ShowShopWithSellAndSelect (includes SELL option), ShowShrineMenuAndSelect, and ShowConfirmMenu (Yes/No).

No game logic changes — UI layer only.