### PR TITLE
fix: add fuzzy Levenshtein matching to EQUIP command

### DIFF
--- a/Dungnz.Tests/EquipmentManagerFuzzyTests.cs
+++ b/Dungnz.Tests/EquipmentManagerFuzzyTests.cs
@@ -1,0 +1,86 @@
+using Dungnz.Models;
+using Dungnz.Systems;
+using Dungnz.Tests.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Dungnz.Tests;
+
+/// <summary>Regression tests for fuzzy Levenshtein matching in HandleEquip (issue #653).</summary>
+public class EquipmentManagerFuzzyTests
+{
+    private static EquipmentManager MakeManager(FakeDisplayService display)
+        => new EquipmentManager(display);
+
+    private static Player MakePlayer()
+        => new Player { Name = "Tester", Attack = 10, Defense = 5, HP = 100, MaxHP = 100 };
+
+    [Fact]
+    public void HandleEquip_TypoInName_FuzzyMatchEquipsAndShowsDidYouMean()
+    {
+        var display = new FakeDisplayService();
+        var manager = MakeManager(display);
+        var player = MakePlayer();
+        var shoulders = new Item
+        {
+            Name = "Sage's Shoulderguards",
+            Type = ItemType.Armor,
+            DefenseBonus = 6,
+            IsEquippable = true,
+            Slot = ArmorSlot.Shoulders
+        };
+        player.Inventory.Add(shoulders);
+
+        // Typo: "Shouldergaurds" instead of "Shoulderguards"
+        manager.HandleEquip(player, "Sage's Shouldergaurds");
+
+        player.EquippedShoulders.Should().NotBeNull("the item should be equipped despite the typo");
+        player.EquippedShoulders.Should().BeSameAs(shoulders);
+        display.Messages.Should().Contain(m => m.Contains("Did you mean") && m.Contains("Sage's Shoulderguards"));
+    }
+
+    [Fact]
+    public void HandleEquip_ExactMatch_NoDidYouMeanMessage()
+    {
+        var display = new FakeDisplayService();
+        var manager = MakeManager(display);
+        var player = MakePlayer();
+        var shoulders = new Item
+        {
+            Name = "Sage's Shoulderguards",
+            Type = ItemType.Armor,
+            DefenseBonus = 6,
+            IsEquippable = true,
+            Slot = ArmorSlot.Shoulders
+        };
+        player.Inventory.Add(shoulders);
+
+        manager.HandleEquip(player, "Sage's Shoulderguards");
+
+        player.EquippedShoulders.Should().BeSameAs(shoulders);
+        display.Messages.Should().NotContain(m => m.Contains("Did you mean"));
+    }
+
+    [Fact]
+    public void HandleEquip_CompletelyUnrelatedTypo_ShowsNotInInventoryError()
+    {
+        var display = new FakeDisplayService();
+        var manager = MakeManager(display);
+        var player = MakePlayer();
+        var sword = new Item { Name = "Iron Sword", Type = ItemType.Weapon, AttackBonus = 5, IsEquippable = true };
+        player.Inventory.Add(sword);
+
+        manager.HandleEquip(player, "zzzzzzzzz");
+
+        display.Errors.Should().ContainSingle().Which.Should().Contain("don't have");
+    }
+
+    [Fact]
+    public void LevenshteinDistance_KnownValues_AreCorrect()
+    {
+        EquipmentManager.LevenshteinDistance("kitten", "sitting").Should().Be(3);
+        EquipmentManager.LevenshteinDistance("", "abc").Should().Be(3);
+        EquipmentManager.LevenshteinDistance("abc", "abc").Should().Be(0);
+        EquipmentManager.LevenshteinDistance("shoulderguards", "shouldergaurds").Should().BeLessThanOrEqualTo(3);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #653.

When a player types a slightly misspelled item name (e.g. `Shouldergaurds` instead of `Shoulderguards`), the EQUIP command now performs a two-pass lookup:

1. **Pass 1** — existing case-insensitive `Contains` match (unchanged behaviour)
2. **Pass 2** — if Pass 1 returns null, fuzzy Levenshtein distance matching finds the closest inventory item within tolerance `Math.Max(3, inputLength / 2)`
   - Single clear match: auto-equips and shows `(Did you mean "X"?)` hint
   - Multiple tied candidates: shows error listing the candidates for disambiguation

## Changes
- `Systems/EquipmentManager.cs`: two-pass lookup + static `LevenshteinDistance` helper
- `Dungnz.Tests/EquipmentManagerFuzzyTests.cs`: 4 regression tests covering the typo path, exact-match path, completely unrelated input, and Levenshtein utility