### PR TITLE
feat: USE command fuzzy matching and no-argument interactive menu

### DIFF
--- a/Display/DisplayService.cs
+++ b/Display/DisplayService.cs
@@ -1639,4 +1639,19 @@ public class ConsoleDisplayService : IDisplayService
             .ToArray();
         return SelectFromMenu(options, _input, "=== EQUIP — Choose an item ===");
     }
+
+    /// <inheritdoc />
+    public Item? ShowUseMenuAndSelect(IReadOnlyList<Item> usable)
+    {
+        var options = usable
+            .Select(item =>
+            {
+                var icon = ItemTypeIcon(item.Type);
+                var stat = PrimaryStatLabel(item);
+                return ($"{icon} {item.Name}  [{stat}]", (Item?)item);
+            })
+            .Append(("↩  Cancel", (Item?)null))
+            .ToArray();
+        return SelectFromMenu(options, _input, "=== Use which item? ===");
+    }
 }

--- a/Display/IDisplayService.cs
+++ b/Display/IDisplayService.cs
@@ -340,4 +340,11 @@ public interface IDisplayService
     /// </summary>
     /// <param name="equippable">The list of equippable items to display.</param>
     Item? ShowEquipMenuAndSelect(IReadOnlyList<Item> equippable);
+
+    /// <summary>
+    /// Presents an arrow-key navigable menu of usable (consumable) items from the player's inventory.
+    /// Returns the selected <see cref="Item"/>, or <c>null</c> if the player cancels.
+    /// </summary>
+    /// <param name="usable">The list of usable items to display.</param>
+    Item? ShowUseMenuAndSelect(IReadOnlyList<Item> usable);
 }

--- a/Dungnz.Tests/Helpers/FakeDisplayService.cs
+++ b/Dungnz.Tests/Helpers/FakeDisplayService.cs
@@ -217,6 +217,19 @@ public class FakeDisplayService : IDisplayService
         }
         return null;
     }
+
+    public Item? ShowUseMenuAndSelect(IReadOnlyList<Item> usable)
+    {
+        AllOutput.Add("use_menu");
+        if (_input != null)
+        {
+            var line = _input.ReadLine()?.Trim() ?? "";
+            var available = usable.ToList();
+            if (int.TryParse(line, out int idx) && idx >= 1 && idx <= available.Count)
+                return available[idx - 1];
+        }
+        return null;
+    }
     
     public void ShowCombatStart(Enemy enemy) { AllOutput.Add($"combat_start:{enemy.Name}"); }
     public void ShowCombatEntryFlags(Enemy enemy) { AllOutput.Add($"combat_flags:{enemy.Name}"); }

--- a/Dungnz.Tests/Helpers/TestDisplayService.cs
+++ b/Dungnz.Tests/Helpers/TestDisplayService.cs
@@ -143,6 +143,7 @@ public class TestDisplayService : IDisplayService
     public Item? ShowCombatItemMenuAndSelect(IReadOnlyList<Item> consumables) => null;
 
     public Item? ShowEquipMenuAndSelect(IReadOnlyList<Item> equippable) => null;
+    public Item? ShowUseMenuAndSelect(IReadOnlyList<Item> usable) => null;
     
     public void ShowCombatStart(Enemy enemy) { AllOutput.Add($"combat_start:{enemy.Name}"); }
     public void ShowCombatEntryFlags(Enemy enemy) { AllOutput.Add($"combat_flags:{enemy.Name}"); }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Choose one class at the start of each run. Bonuses are applied on top of base st
 | `look` | `l` | Redescribe current room |
 | `examine <target>` | `ex` | Inspect an enemy or item |
 | `take <item>` | `get` | Pick up an item |
-| `use <item>` | | Use consumable or equip gear |
+| `use <item>` | | Use a consumable item; omit item name to pick from an interactive menu; accepts fuzzy/typo matching |
 | `inventory` | `inv`, `i` | List carried items |
 | `equipment` | `gear` | Show equipped items and their bonuses |
 | `equip <item>` | | Equip a weapon or armour from inventory; omit item name to pick from an interactive menu |


### PR DESCRIPTION
## Summary

Implements two improvements to the USE command, mirroring the patterns added to EQUIP in PRs #655 and #656.

### Changes

- **`Display/IDisplayService.cs`**: Added `ShowUseMenuAndSelect(IReadOnlyList<Item> usable)` declaration
- **`Display/DisplayService.cs`**: Implemented `ShowUseMenuAndSelect` using `SelectFromMenu` with title "Use which item?"
- **`Dungnz.Tests/Helpers/FakeDisplayService.cs`**: Added `ShowUseMenuAndSelect` stub (records `use_menu` in AllOutput)
- **`Dungnz.Tests/Helpers/TestDisplayService.cs`**: Added stub returning `null`
- **`Engine/GameLoop.cs` `HandleUse`**:
  - No-arg path: shows interactive consumable menu instead of "Use what?" error
  - Fuzzy Levenshtein fallback after Contains lookup fails
- **`Dungnz.Tests/GameLoopCommandTests.cs`**: 5 new tests covering all new behaviour
- **`README.md`**: Updated `use` command description

Closes #658
Closes #659

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>