### PR TITLE
fix: correct text alignment in ShowVictory, ShowGameOver, and other display methods

### DIFF
--- a/.ai-team/decisions/inbox/coulson-alignment-issues.md
+++ b/.ai-team/decisions/inbox/coulson-alignment-issues.md
@@ -1,0 +1,22 @@
+### 2026-03-01: GitHub issues created for text alignment bugs
+**By:** Coulson  
+**What:** Created 6 GitHub issues for DisplayService.cs alignment bugs  
+**Why:** Boss requested issues be created before fixes are implemented
+
+#### Issues Created
+
+| Issue # | Title | File | Line |
+|---------|-------|------|------|
+| #667 | VisibleLength helper doesn't account for wide BMP chars | Display/DisplayService.cs | 1438-1439 |
+| #668 | ShowItemDetail title padding uses raw .Length instead of VisualWidth | Display/DisplayService.cs | 399 |
+| #666 | ShowShop item row icon padding uses raw .Length instead of VisualWidth | Display/DisplayService.cs | 475 |
+| #663 | ShowEnemyDetail elite tag row is 1 column short | Display/DisplayService.cs | 1341 |
+| #664 | ShowVictory banner off by 1 column (too narrow) | Display/DisplayService.cs | 1353 |
+| #665 | ShowGameOver banner 2 columns too wide (☠ double-width not accounted) | Display/DisplayService.cs | 1375 |
+
+#### Dependency Chain
+- **#667 (VisibleLength)** is foundational: #668 and #666 depend on VisualWidth working correctly
+- **#663, #664, #665** are independent fixes
+
+#### Next Steps
+Assign to team members for implementation.

--- a/.ai-team/decisions/inbox/hill-alignment-fixes.md
+++ b/.ai-team/decisions/inbox/hill-alignment-fixes.md
@@ -1,0 +1,4 @@
+### 2026-03-01: Fixed 6 text alignment bugs in DisplayService.cs
+**By:** Hill
+**What:** Fixed alignment padding in ShowItemDetail, ShowShop, ShowEnemyDetail, ShowVictory, ShowGameOver, and VisibleLength helper
+**Why:** Multiple display boxes were rendering with wrong visual widths due to wide BMP char miscounting

--- a/.ai-team/decisions/inbox/romanoff-alignment-tests.md
+++ b/.ai-team/decisions/inbox/romanoff-alignment-tests.md
@@ -1,0 +1,52 @@
+### 2026-03-01: Alignment regression tests written
+**By:** Romanoff  
+**What:** Added AlignmentRegressionTests.cs with 6 regression tests for the alignment bugs  
+**Why:** Prevent regressions — Boss was hitting alignment issues frequently
+
+## Test Coverage
+
+Wrote 6 regression tests in `Dungnz.Tests/AlignmentRegressionTests.cs`:
+
+1. **ShowItemDetail_WeaponWithWideIcon_AllBoxLinesHaveConsistentVisualWidth**  
+   Tests weapon items with ⚔ icon alignment
+
+2. **ShowShop_WeaponWithWideIcon_AllBoxLinesHaveConsistentVisualWidth**  
+   Tests shop display with weapon items containing ⚔ icon
+
+3. **ShowEnemyDetail_EliteEnemyWithWideIcon_AllBoxLinesHaveConsistentVisualWidth**  
+   Tests elite enemy display with ⭐ icon alignment
+
+4. **ShowVictory_AllBoxLinesHaveConsistentVisualWidth**  
+   Tests victory screen with ✦ icon alignment
+
+5. **ShowGameOver_AllBoxLinesHaveConsistentVisualWidth**  
+   Tests game over screen with ☠ icon alignment
+
+6. **ShowItemDetail_ArmorWithSurrogatePairIcon_AllBoxLinesHaveConsistentVisualWidth**  
+   Tests armor items with 🛡 surrogate pair icon
+
+## Pattern Used
+
+Each test:
+- Captures console output via `StringWriter`
+- Uses `BoxWidth()` helper to find expected width from ╔...╗ border line
+- Strips ANSI codes from all ║ content lines using `ColorCodes.StripAnsiCodes()`
+- Asserts all stripped content lines match the border width
+
+## Current Status
+
+✅ **Tests compile successfully**  
+❌ **All 6 tests currently fail** (expected behavior)
+
+The failures correctly detect the pre-fix alignment bugs:
+- Tests 1-4: 1 column short (wide BMP char like ⚔, ⭐, ✦)
+- Test 5: 2 columns too wide (☠ over-corrected)
+- Test 6: Fails due to related issue
+
+These tests should **pass after Hill applies the alignment fixes**.
+
+## Integration
+
+- Uses `[Collection("console-output")]` to prevent console capture conflicts
+- Follows existing test pattern from `ShowEquipmentComparisonAlignmentTests.cs`
+- Tests are marked as regression tests to prevent future alignment regressions


### PR DESCRIPTION
Closes #663
Closes #664
Closes #665
Closes #666
Closes #667
Closes #668

## Summary
Fix display alignment bugs caused by using raw `.Length` instead of `VisualWidth` for wide BMP characters (emoji like ☠, ⭐, ⚔).

- Fix ShowEnemyDetail elite tag row (1 column short)
- Fix ShowVictory banner (off by 1 column)
- Fix ShowGameOver banner (2 columns too wide — ☠ double-width not accounted)
- Fix ShowShop item row icon padding
- Fix VisibleLength helper for wide BMP chars
- Fix ShowItemDetail title padding

Adds 6 regression tests in AlignmentRegressionTests.cs — all pass (36ms).