### PR TITLE
fix: register GoblinWarchief for JSON polymorphic serialization

### DIFF
--- a/Models/Enemy.cs
+++ b/Models/Enemy.cs
@@ -19,6 +19,7 @@ namespace Dungnz.Models;
 [JsonDerivedType(typeof(VampireLord), "VampireLord")]
 [JsonDerivedType(typeof(Wraith), "Wraith")]
 [JsonDerivedType(typeof(DungeonBoss), "DungeonBoss")]
+[JsonDerivedType(typeof(GoblinWarchief), "goblinwarchief")]
 [JsonDerivedType(typeof(LichKing), "lichking")]
 [JsonDerivedType(typeof(StoneTitan), "stonetitan")]
 [JsonDerivedType(typeof(ShadowWraith), "shadowwraith")]


### PR DESCRIPTION
Closes #701\n\n## What\n\nAdds the missing [JsonDerivedType(typeof(GoblinWarchief), "goblinwarchief")] attribute to the Enemy base class in Models/Enemy.cs.\n\n## Why\n\nGoblinWarchief extends DungeonBoss but was not in the polymorphic type registry. Saving a game with a GoblinWarchief present caused:\n\nSystem.NotSupportedException: Runtime type 'Dungnz.Systems.Enemies.GoblinWarchief' is not supported by polymorphic type 'Dungnz.Models.Enemy'\n\n## Testing\n\n- Build passes (dotnet build)\n- Load floor 1 (where GoblinWarchief spawns) and use the save command