### PR TITLE
fix(docs): correct XML doc inaccuracies in Engine layer

### DIFF
--- a/Engine/CombatEngine.cs
+++ b/Engine/CombatEngine.cs
@@ -193,6 +193,18 @@ public class CombatEngine : ICombatEngine
     /// Optional narration service used to pick varied combat messages; a default instance
     /// sharing <paramref name="rng"/> is created when <see langword="null"/>.
     /// </param>
+    /// <param name="inventoryManager">
+    /// Optional pre-configured inventory manager used for item use during combat;
+    /// a default instance is created when <see langword="null"/>.
+    /// </param>
+    /// <param name="navigator">
+    /// Optional menu navigator used for arrow-key ability and item menus during combat.
+    /// Falls back to legacy numbered <see cref="IInputReader.ReadLine"/> input when <see langword="null"/>.
+    /// </param>
+    /// <param name="difficulty">
+    /// Optional difficulty settings applied to damage scaling and flee mechanics.
+    /// Defaults to <see cref="Difficulty.Normal"/> when <see langword="null"/>.
+    /// </param>
     public CombatEngine(IDisplayService display, IInputReader? input = null, Random? rng = null, GameEvents? events = null, StatusEffectManager? statusEffects = null, AbilityManager? abilities = null, NarrationService? narration = null, InventoryManager? inventoryManager = null, IMenuNavigator? navigator = null, DifficultySettings? difficulty = null)
     {
         _display = display;

--- a/Engine/DungeonGenerator.cs
+++ b/Engine/DungeonGenerator.cs
@@ -57,7 +57,7 @@ public class DungeonGenerator
     /// Defaults to <see langword="null"/> (treated as Normal, multiplier = 1.0).
     /// </param>
     /// <param name="floor">
-    /// The dungeon floor number (1–5), used to select the appropriate themed description pool
+    /// The dungeon floor number (1–8), used to select the appropriate themed description pool
     /// via <see cref="RoomDescriptions.ForFloor"/>. Defaults to 1.
     /// </param>
     /// <returns>

--- a/Engine/EnemyFactory.cs
+++ b/Engine/EnemyFactory.cs
@@ -48,9 +48,12 @@ public static class EnemyFactory
     }
 
     /// <summary>
-    /// Creates a randomly chosen enemy from the full pool of available types, with a
-    /// 5 % chance that the selected enemy is promoted to an Elite variant (1.5× stats,
+    /// Creates a randomly chosen enemy from a hardcoded set of nine base types (Goblin,
+    /// Skeleton, Troll, DarkKnight, GoblinShaman, StoneGolem, Wraith, VampireLord, Mimic),
+    /// with a 5 % chance that the selected enemy is promoted to an Elite variant (1.5× stats,
     /// "Elite" name prefix, and <see cref="Enemy.IsElite"/> flag set).
+    /// Note: the dungeon generator uses <see cref="CreateScaled"/> with floor-specific pools
+    /// from <see cref="FloorSpawnPools"/> rather than this method.
     /// </summary>
     /// <param name="rng">
     /// The random-number generator used to pick the enemy type and decide elite status.

--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -1434,18 +1434,10 @@ public class GameLoop
     }
 
     /// <summary>
-    /// Displays a contextual death banner, a floor-specific opening line, a cause-of-death
-    /// line (trap or named killer), and a class-specific epitaph. Stats and achievements
-    /// should be displayed by the caller after this method returns.
-    /// </summary>
-    /// <param name="killedBy">Name of the enemy that killed the player, or <see langword="null"/> for non-combat deaths.</param>
-    /// <param name="byTrap">
-    /// <see langword="true"/> when the player was killed by an environmental hazard rather than a monster.
-    /// </param>
-    /// <summary>
     /// Single chokepoint for all player-death paths. Records stats, shows the game-over screen,
     /// and sets <see cref="_gameOver"/>. Every death path must call this instead of duplicating the sequence.
     /// </summary>
+    /// <param name="killedBy">Name of the enemy or hazard that killed the player.</param>
     private void ExitRun(string killedBy)
     {
         _stats.FinalLevel = _player.Level;
@@ -1458,6 +1450,13 @@ public class GameLoop
         _gameOver = true;
     }
 
+    /// <summary>
+    /// Delegates to <see cref="IDisplayService.ShowGameOver"/> to render the death screen.
+    /// </summary>
+    /// <param name="killedBy">Name of the enemy that killed the player, or <see langword="null"/> for non-combat deaths.</param>
+    /// <param name="byTrap">
+    /// <see langword="true"/> when the player was killed by an environmental hazard rather than a monster.
+    /// </param>
     private void ShowGameOver(string? killedBy = null, bool byTrap = false)
     {
         _display.ShowGameOver(_player, killedBy, _stats);


### PR DESCRIPTION
Closes #704

## Changes

### `Engine/CombatEngine.cs`
Added three missing `<param>` entries for the `CombatEngine` constructor: `inventoryManager`, `navigator`, and `difficulty`. These parameters were present in the signature but entirely undocumented.

### `Engine/GameLoop.cs`
Removed the orphaned double-`<summary>` block from `ExitRun`. The block that belonged to `ShowGameOver(string?, bool)` was incorrectly placed on `ExitRun`, giving it two stacked summaries and leaving `ShowGameOver` undocumented. Fixed by:
- Stripping the stray summary/params from `ExitRun` and adding a proper single doc block for it
- Adding a dedicated `<summary>`, `<param name="killedBy">`, and `<param name="byTrap">` block directly above `ShowGameOver`

### `Engine/DungeonGenerator.cs`
Corrected the `floor` parameter range from `(1–5)` to `(1–8)` to match the actual 8-floor dungeon.

### `Engine/EnemyFactory.cs`
Replaced the inaccurate "full pool of available types" claim in `CreateRandom` with an accurate description listing the 9 hardcoded types the method actually uses. Added a note directing readers to `CreateScaled` + `FloorSpawnPools` as the canonical dungeon-generation path.

## Review checklist
- [x] XML doc text only — no logic changes
- [x] No `<param>` names or cref targets changed