### PR TITLE
fix(docs): correct XML doc inaccuracies in Models layer

### DIFF
--- a/Models/LootTable.cs
+++ b/Models/LootTable.cs
@@ -137,9 +137,11 @@ public class LootTable
     /// Executes a full loot roll for a defeated enemy, returning any item that was selected and
     /// the gold amount to award. Explicit drops (registered via <see cref="AddDrop"/>) are tried
     /// first; if none trigger, a 30 % chance of a random tiered item applies based on
-    /// <paramref name="playerLevel"/>. Elite enemies are guaranteed at least a tier-2 item.
-    /// Bosses (DungeonBoss or subclass) always drop one Legendary item when the Legendary pool is loaded.
-    /// Floors 6-8 chest/room loot has a 5% Legendary chance.
+    /// <paramref name="playerLevel"/>. Elite enemies below level 4 are guaranteed at least a
+    /// tier-2 item (at level 4+ the normal tiered roll already yields tier-2 or better, so the
+    /// guarantee has no additional effect). Bosses (DungeonBoss or subclass) always drop one
+    /// Legendary item when the Legendary pool is loaded. Floors 5–8 have an Epic drop chance
+    /// (8 % on floors 5–6, 15 % on floors 7–8); floors 6–8 also have a 5 % Legendary chance.
     /// </summary>
     /// <param name="enemy">The defeated enemy, used to check <see cref="Enemy.IsElite"/> for tier escalation.</param>
     /// <param name="playerLevel">The player's current level, used to select the appropriate item tier pool.</param>

--- a/Models/PlayerStats.cs
+++ b/Models/PlayerStats.cs
@@ -3,8 +3,9 @@ namespace Dungnz.Models;
 public partial class Player
 {
     /// <summary>
-    /// Gets or sets the player's chosen class (Warrior, Mage, or Rogue), which determines
-    /// starting stat modifiers, the mana pool size, and passive combat traits.
+    /// Gets or sets the player's chosen class (Warrior, Mage, Rogue, Paladin, Necromancer,
+    /// or Ranger), which determines starting stat modifiers, the mana pool size, and passive
+    /// combat traits.
     /// </summary>
     public PlayerClass Class { get; set; } = PlayerClass.Warrior;
     /// <summary>
@@ -17,44 +18,44 @@ public partial class Player
     public int HP { get; set; } = 100;
 
     /// <summary>
-    /// Gets the player's maximum hit points. Increases on level-up via <see cref="LevelUp"/>,
+    /// Gets or sets the player's maximum hit points. Increases on level-up via <see cref="LevelUp"/>,
     /// via <see cref="FortifyMaxHP"/>, and when certain equipment with a positive
     /// <see cref="Item.StatModifier"/> is equipped.
     /// </summary>
     public int MaxHP { get; set; } = 100;
 
     /// <summary>
-    /// Gets the player's base attack power used to calculate raw damage against enemies before
+    /// Gets or sets the player's base attack power used to calculate raw damage against enemies before
     /// their defense is subtracted.
     /// </summary>
     public int Attack { get; set; } = 10;
 
     /// <summary>
-    /// Gets the player's base defense value used to reduce incoming damage and influence
+    /// Gets or sets the player's base defense value used to reduce incoming damage and influence
     /// dodge-chance calculations during combat.
     /// </summary>
     public int Defense { get; set; } = 5;
 
     /// <summary>
-    /// Gets the player's total accumulated experience points. Callers must check this value
+    /// Gets or sets the player's total accumulated experience points. Callers must check this value
     /// externally to decide when to call <see cref="LevelUp"/>.
     /// </summary>
     public int XP { get; set; }
 
     /// <summary>
-    /// Gets the player's current level. Starts at 1 and increments each time
+    /// Gets or sets the player's current level. Starts at 1 and increments each time
     /// <see cref="LevelUp"/> is called.
     /// </summary>
     public int Level { get; set; } = 1;
 
     /// <summary>
-    /// Gets the player's current mana. Spent by abilities via <see cref="SpendMana"/> and
+    /// Gets or sets the player's current mana. Spent by abilities via <see cref="SpendMana"/> and
     /// restored via <see cref="RestoreMana"/>; always clamped between 0 and <see cref="MaxMana"/>.
     /// </summary>
     public int Mana { get; set; } = 30;
 
     /// <summary>
-    /// Gets the player's maximum mana capacity. Increases on level-up and via
+    /// Gets or sets the player's maximum mana capacity. Increases on level-up and via
     /// <see cref="FortifyMaxMana"/>.
     /// </summary>
     public int MaxMana { get; set; } = 30;


### PR DESCRIPTION
Closes #705

## Changes

### `Models/PlayerStats.cs` — 7 properties: "Gets" → "Gets or sets"

`MaxHP`, `Attack`, `Defense`, `XP`, `Level`, `Mana`, and `MaxMana` all declare `{ get; set; }` and have their setters used directly in `LevelUp()`, the save/load system, and class initialization paths. Documenting them as read-only "Gets" was inaccurate. Updated to "Gets or sets" to match the actual accessors.

(`ComboPoints { get; private set; }` is untouched — "Gets" is correct for a private setter.)

### `Models/PlayerStats.cs` — Class property: 3 → 6 classes in doc

Updated from "Warrior, Mage, or Rogue" to "Warrior, Mage, Rogue, Paladin, Necromancer, or Ranger" to match the current `PlayerClass` enum.

### `Models/LootTable.cs` — `RollDrop` elite guarantee caveat

Added the `playerLevel < 4` condition to the elite tier-2 guarantee note, and documented the Epic drop chances for floors 5–8 (8 % on 5–6, 15 % on 7–8) which were entirely absent from the summary.

## Review checklist
- [x] XML doc text only — zero logic changes
- [x] All `<param>` names and cref targets unchanged