### PR TITLE
feat: Spectre.Console SelectionPrompt menus

### DIFF
--- a/Display/ConsoleMenuNavigator.cs
+++ b/Display/ConsoleMenuNavigator.cs
@@ -9,6 +9,7 @@ namespace Dungnz.Display;
 /// Falls back to numbered ReadLine selection when stdin is redirected (CI, piped input).
 /// </summary>
 [ExcludeFromCodeCoverage]   // TTY-only class; tests inject FakeMenuNavigator
+[Obsolete("Use SpectreDisplayService with SelectionPrompt instead")]
 public sealed class ConsoleMenuNavigator : IMenuNavigator
 {
     /// <summary>Presents a cursor-navigable list and returns the selected value.</summary>


### PR DESCRIPTION
Closes #714

Replaces ConsoleMenuNavigator arrow-key menus with Spectre.Console SelectionPrompt<T> for all selection flows. Keyboard navigation, clean display. ConsoleMenuNavigator marked [Obsolete].