### PR TITLE
feat: Spectre.Console combat UI with HP bars and enemy art (#715)

### DIFF
--- a/Display/SpectreDisplayService.cs
+++ b/Display/SpectreDisplayService.cs
@@ -49,7 +49,7 @@ public sealed class SpectreDisplayService : IDisplayService
             foreach (var e in playerEffects)
             {
                 var color = e.IsBuff ? "purple" : "red";
-                playerCell.Append($"[{color}][{EffectIcon(e.Effect)}{Markup.Escape(e.Effect.ToString())} {e.RemainingTurns}t][/] ");
+                playerCell.Append($"[{color}][[{EffectIcon(e.Effect)}{Markup.Escape(e.Effect.ToString())} {e.RemainingTurns}t]][/] ");
             }
         }
 
@@ -64,7 +64,7 @@ public sealed class SpectreDisplayService : IDisplayService
             foreach (var e in enemyEffects)
             {
                 var color = e.IsBuff ? "purple" : "red";
-                enemyCell.Append($"[{color}][{EffectIcon(e.Effect)}{Markup.Escape(e.Effect.ToString())} {e.RemainingTurns}t][/] ");
+                enemyCell.Append($"[{color}][[{EffectIcon(e.Effect)}{Markup.Escape(e.Effect.ToString())} {e.RemainingTurns}t]][/] ");
             }
         }
 


### PR DESCRIPTION
## Summary

Implements all combat-facing display methods in `SpectreDisplayService` for issue #715.

### Changes

- **ShowCombat**: `Rule` widget with bold red title for dramatic combat separators
- **ShowCombatStatus**: 2-column `Table` (no border) with player/enemy side-by-side
  - HP bars colour-coded: green >50%, yellow 25-50%, red <25%
  - Mana bar in blue
  - Active effects shown as inline purple (buff) / red (debuff) tags with icon + duration
- **ShowCombatMessage**: Indented `[white]` markup line for round-by-round narrative
- **ShowCombatStart**: `Rule` + bold red enemy name announcement panel
- **ShowCombatEntryFlags**: Elite ⭐ and ENRAGED ⚡ badges
- **ShowEnemyArt**: Rounded `Panel` with enemy name header; art colored yellow for elite, red for regular; silently skips if no `AsciiArt`
- **Private helpers**: `BuildBar`, `BuildHpBar`, `EffectIcon`

All non-combat stubs remain untouched.

### Build
`dotnet build` — 0 errors, 32 pre-existing warnings (unchanged).