### PR TITLE
fix: remove stale XML param tags from private enemy constructors (#727)

### DIFF
--- a/Systems/Enemies/DarkKnight.cs
+++ b/Systems/Enemies/DarkKnight.cs
@@ -12,14 +12,6 @@ public class DarkKnight : Enemy
     /// Initialises the Dark Knight using either the provided external stats from config
     /// or built-in fallback defaults, and populates the loot table from item config when available.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (45 HP, 18 ATK, 12 DEF, 55 XP, 20–40 gold).
-    /// </param>
-    /// <param name="itemConfig">
-    /// The loaded item configuration used to source Dark Blade and Knight's Armor drops,
-    /// or <see langword="null"/> to create fallback inline items.
-    /// </param>
     [System.Text.Json.Serialization.JsonConstructor]
     private DarkKnight() { }
 

--- a/Systems/Enemies/DungeonBoss.cs
+++ b/Systems/Enemies/DungeonBoss.cs
@@ -4,7 +4,7 @@ using Dungnz.Systems;
 
 /// <summary>Defines an HP-threshold phase for a boss, triggering a named ability once.</summary>
 /// <param name="HpPercent">Fraction of max HP (0.0–1.0) at or below which the ability fires.</param>
-/// <param name="AbilityName">The ability identifier passed to <see cref="CombatEngine.ExecuteBossPhaseAbility"/>.</param>
+/// <param name="AbilityName">The ability identifier passed to the boss phase ability handler in <see cref="Dungnz.Engine.CombatEngine"/>.</param>
 public record BossPhase(double HpPercent, string AbilityName);
 
 /// <summary>
@@ -48,7 +48,7 @@ public class DungeonBoss : Enemy
 
     /// <summary>
     /// Periodic turn-based abilities. Key = turn interval (fires when <c>TurnCount % key == 0</c>),
-    /// value = ability name passed to <see cref="Engine.CombatEngine.ExecuteBossPhaseAbility"/>.
+    /// value = ability name passed to the boss phase ability handler in <see cref="Engine.CombatEngine"/>.
     /// </summary>
     public Dictionary<int, string> TurnActions { get; } = new();
 
@@ -59,14 +59,6 @@ public class DungeonBoss : Enemy
     /// or built-in fallback defaults. Optionally populates the loot table with a Boss Key
     /// item from the item configuration.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (100 HP, 22 ATK, 15 DEF, 100 XP, 50–100 gold).
-    /// </param>
-    /// <param name="itemConfig">
-    /// The loaded item configuration used to source the Boss Key drop,
-    /// or <see langword="null"/> to create a fallback inline item.
-    /// </param>
     [System.Text.Json.Serialization.JsonConstructor]
     private DungeonBoss() { }
 

--- a/Systems/Enemies/Goblin.cs
+++ b/Systems/Enemies/Goblin.cs
@@ -12,11 +12,6 @@ public class Goblin : Enemy
     /// Initialises the Goblin using either the provided external stats from config
     /// or built-in fallback defaults.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (20 HP, 8 ATK, 2 DEF, 15 XP, 2–8 gold).
-    /// </param>
-    /// <param name="itemConfig">Item configuration reserved for future loot table expansion; currently unused.</param>
     [System.Text.Json.Serialization.JsonConstructor]
     private Goblin() { }
 

--- a/Systems/Enemies/GoblinShaman.cs
+++ b/Systems/Enemies/GoblinShaman.cs
@@ -13,11 +13,6 @@ public class GoblinShaman : Enemy
     /// or built-in fallback defaults. Sets <see cref="Enemy.AppliesPoisonOnHit"/> to enable
     /// per-hit poison application during combat.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (25 HP, 10 ATK, 4 DEF, 25 XP, 5–15 gold).
-    /// </param>
-    /// <param name="itemConfig">Item configuration reserved for future loot table expansion; currently unused.</param>
     [System.Text.Json.Serialization.JsonConstructor]
     private GoblinShaman() { }
 

--- a/Systems/Enemies/Mimic.cs
+++ b/Systems/Enemies/Mimic.cs
@@ -15,11 +15,6 @@ public class Mimic : Enemy
     /// or built-in fallback defaults. Sets <see cref="Enemy.IsAmbush"/> to <see langword="true"/>
     /// so the player cannot act during the first turn of the encounter.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (40 HP, 14 ATK, 8 DEF, 40 XP, 10–25 gold).
-    /// </param>
-    /// <param name="itemConfig">Item configuration reserved for future loot table expansion; currently unused.</param>
     [System.Text.Json.Serialization.JsonConstructor]
     private Mimic() { _rng = new Random(); } // RNG-ok: JsonConstructor (deserialization only)
 

--- a/Systems/Enemies/Skeleton.cs
+++ b/Systems/Enemies/Skeleton.cs
@@ -12,14 +12,6 @@ public class Skeleton : Enemy
     /// Initialises the Skeleton using either the provided external stats from config
     /// or built-in fallback defaults, and populates the loot table from item config when available.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (30 HP, 12 ATK, 5 DEF, 25 XP, 5–15 gold).
-    /// </param>
-    /// <param name="itemConfig">
-    /// The loaded item configuration used to source Rusty Sword and Bone Fragment drops,
-    /// or <see langword="null"/> to create fallback inline items.
-    /// </param>
     [System.Text.Json.Serialization.JsonConstructor]
     private Skeleton() { }
 

--- a/Systems/Enemies/StoneGolem.cs
+++ b/Systems/Enemies/StoneGolem.cs
@@ -13,11 +13,6 @@ public class StoneGolem : Enemy
     /// or built-in fallback defaults. Sets <see cref="Enemy.IsImmuneToEffects"/> to prevent
     /// any status effects from being applied.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (90 HP, 8 ATK, 20 DEF, 50 XP, 10–25 gold).
-    /// </param>
-    /// <param name="itemConfig">Item configuration reserved for future loot table expansion; currently unused.</param>
     [System.Text.Json.Serialization.JsonConstructor]
     private StoneGolem() { }
 

--- a/Systems/Enemies/Troll.cs
+++ b/Systems/Enemies/Troll.cs
@@ -12,14 +12,6 @@ public class Troll : Enemy
     /// Initialises the Troll using either the provided external stats from config
     /// or built-in fallback defaults, and populates the loot table from item config when available.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (60 HP, 10 ATK, 8 DEF, 40 XP, 10–25 gold).
-    /// </param>
-    /// <param name="itemConfig">
-    /// The loaded item configuration used to source the Troll Hide drop,
-    /// or <see langword="null"/> to create a fallback inline item.
-    /// </param>
     [System.Text.Json.Serialization.JsonConstructor]
     private Troll() { }
 

--- a/Systems/Enemies/VampireLord.cs
+++ b/Systems/Enemies/VampireLord.cs
@@ -13,11 +13,6 @@ public class VampireLord : Enemy
     /// or built-in fallback defaults. Sets <see cref="Enemy.LifestealPercent"/> to 50%
     /// so the Vampire Lord restores HP equal to half the damage it deals each attack.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (80 HP, 16 ATK, 12 DEF, 60 XP, 15–30 gold).
-    /// </param>
-    /// <param name="itemConfig">Item configuration reserved for future loot table expansion; currently unused.</param>
     [System.Text.Json.Serialization.JsonConstructor]
     private VampireLord() { }
 

--- a/Systems/Enemies/Wraith.cs
+++ b/Systems/Enemies/Wraith.cs
@@ -13,11 +13,6 @@ public class Wraith : Enemy
     /// or built-in fallback defaults. Sets <see cref="Enemy.FlatDodgeChance"/> to 30%
     /// to represent its ethereal, hard-to-hit nature.
     /// </summary>
-    /// <param name="stats">
-    /// External stats loaded from the enemy config file, or <see langword="null"/> to use
-    /// hard-coded defaults (35 HP, 18 ATK, 2 DEF, 35 XP, 8–20 gold).
-    /// </param>
-    /// <param name="itemConfig">Item configuration reserved for future loot table expansion; currently unused.</param>
     [System.Text.Json.Serialization.JsonConstructor]
     private Wraith() { }
 


### PR DESCRIPTION
Fixes #727

Removed stale `<param name="stats">` and `<param name="itemConfig">` XML doc tags from the private `[JsonConstructor]` constructors in all 10 enemy classes. These private constructors have no parameters, so the `<param>` tags caused CS1572 warnings. The public constructors retain their correct doc comments.