### PR TITLE
fix: escape literal brackets in intro screen markup

### DIFF
--- a/Display/SpectreDisplayService.cs
+++ b/Display/SpectreDisplayService.cs
@@ -661,7 +661,7 @@ public sealed class SpectreDisplayService : IDisplayService
             Header = new PanelHeader("[grey]Lore[/]"),
         };
         AnsiConsole.Write(panel);
-        AnsiConsole.MarkupLine("[yellow][ Press Enter to begin your descent... ][/]");
+        AnsiConsole.MarkupLine("[yellow][[ Press Enter to begin your descent... ]][/]");
         Console.ReadLine();
         AnsiConsole.WriteLine();
         return false;


### PR DESCRIPTION
Closes #731

Escape the literal [ and ] decorators around the "Press Enter" prompt in ShowIntroNarrative(). Spectre.Console treats [...] as markup tags. The unescaped brackets caused StyleParser.Parse to be called with an empty string, crashing the game on launch.

Before: AnsiConsole.MarkupLine("[yellow][ Press Enter to begin your descent... ][/]");
After:  AnsiConsole.MarkupLine("[yellow][[ Press Enter to begin your descent... ]][/]");