### PR TITLE
Fix MAP crash: escape '@' in player position marker

### DIFF
--- a/Display/SpectreDisplayService.cs
+++ b/Display/SpectreDisplayService.cs
@@ -545,7 +545,7 @@ public sealed class SpectreDisplayService : IDisplayService
 
     private static string GetMapRoomSymbol(Room r, Room currentRoom)
     {
-        if (r == currentRoom)                               return "[bold yellow][@][/]";
+        if (r == currentRoom)                               return "[bold yellow][[@]][/]";
         if (!r.Visited)                                     return "[grey][[?]][/]";
         if (r.IsExit && r.Enemy != null && r.Enemy.HP > 0) return "[bold red][[B]][/]";
         if (r.IsExit)                                       return "[white][[E]][/]";


### PR DESCRIPTION
## Summary

Fixes #734

The MAP command crashed with `InvalidOperationException: Could not find color or style '@'` because `GetMapRoomSymbol()` returned `"[bold yellow][@][/]"` — the `@` inside unescaped brackets was parsed as a Spectre.Console style name.

## Change

Single character fix on line 548:

```diff
- if (r == currentRoom) return "[bold yellow][@][/]";
+ if (r == currentRoom) return "[bold yellow][[@]][/]";
```

All other symbols in the method already use `[[...]][/]` double-bracket escaping correctly — this one was overlooked.

## Testing

- Build: 0 errors, 0 warnings
- MAP command no longer throws on launch