### PR TITLE
test: fix CryptPriest_HealsOnTurn2And4 to match CombatEngine check-first pattern

### DIFF
--- a/Dungnz.Tests/EnemyExpansionTests.cs
+++ b/Dungnz.Tests/EnemyExpansionTests.cs
@@ -238,11 +238,12 @@ public class EnemyExpansionTests
     private bool SimulateSelfHealTick(Enemy enemy)
     {
         if (enemy.SelfHealEveryTurns <= 0) return false;
-        // Mirrors CombatEngine's decrement-first approach
-        enemy.SelfHealCooldown--;
-        if (enemy.SelfHealCooldown <= 0)
+        // Mirrors CombatEngine's check-first pattern: check → if 0 heal → else decrement
+        if (enemy.SelfHealCooldown > 0)
+            enemy.SelfHealCooldown--;
+        else
         {
-            enemy.SelfHealCooldown = enemy.SelfHealEveryTurns;
+            enemy.SelfHealCooldown = enemy.SelfHealEveryTurns - 1;
             enemy.HP = Math.Min(enemy.MaxHP, enemy.HP + enemy.SelfHealAmount);
             return true;
         }

--- a/Systems/Enemies/CryptPriest.cs
+++ b/Systems/Enemies/CryptPriest.cs
@@ -37,7 +37,7 @@ public class CryptPriest : Enemy
 
         SelfHealAmount = 10;
         SelfHealEveryTurns = 2;
-        SelfHealCooldown = 1; // first heal fires on turn 2 (decrement-first: 1→0=fire)
+        SelfHealCooldown = 1; // first heal fires on turn 2 (check-first: check==1 no → decrement to 0, then check==0 → heal)
 
         AddLoot(itemConfig);
     }


### PR DESCRIPTION
The CryptPriest self-heal timing test was written assuming a decrement-first cooldown pattern, but CombatEngine uses a check-first pattern. After the bug fix in PR #750 corrected SelfHealCooldown to 1, the test's turn expectations needed to be updated to match the actual engine behavior.