### PR TITLE
Add self-contained executable artifacts to GitHub releases

### DIFF
--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -43,12 +43,48 @@ jobs:
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
+      - name: Setup .NET
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish linux-x64
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          dotnet publish Dungnz.csproj \
+            -c Release \
+            -r linux-x64 \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:PublishReadyToRun=true \
+            -o publish/linux-x64
+
+      - name: Publish win-x64
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          dotnet publish Dungnz.csproj \
+            -c Release \
+            -r win-x64 \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:PublishReadyToRun=true \
+            -o publish/win-x64
+
+      - name: Archive artifacts
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          cd publish/linux-x64 && zip -j ../../dungnz-linux-x64.zip * && cd ../..
+          cd publish/win-x64 && zip -j ../../dungnz-win-x64.zip * && cd ../..
+
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
+            dungnz-linux-x64.zip \
+            dungnz-win-x64.zip \
             --title "${{ steps.version.outputs.tag }}" \
             --generate-notes \
             --latest


### PR DESCRIPTION
Closes #764

## Changes

Modifies `squad-release.yml` to publish and attach downloadable executables:

1. **Publish step**: Builds linux-x64 and win-x64 self-contained executables with:
   - `PublishSingleFile=true` (single executable, no DLL sprawl)
   - `PublishReadyToRun=true` (optimized startup time)
   - `--self-contained` (includes .NET runtime, no SDK required)

2. **Archive step**: Zips each platform's binaries into `dungnz-{platform}.zip`

3. **Release step**: Attaches zip files to the GitHub release

## Benefits

- **Zero friction for players**: Download zip, extract, run — no .NET SDK needed
- **Cross-platform**: Linux and Windows binaries included
- **Optimized**: Single-file executables with fast startup