### PR TITLE
feat: consolidate JsonSerializerOptions into DataJsonOptions

### DIFF
--- a/Systems/AffixRegistry.cs
+++ b/Systems/AffixRegistry.cs
@@ -56,7 +56,6 @@ internal record AffixConfigData
 /// </summary>
 public static class AffixRegistry
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     private static IReadOnlyList<AffixDefinition> _prefixes = Array.Empty<AffixDefinition>();
     private static IReadOnlyList<AffixDefinition> _suffixes = Array.Empty<AffixDefinition>();
@@ -70,7 +69,7 @@ public static class AffixRegistry
         if (!File.Exists(path)) return;
 
         var json = File.ReadAllText(path);
-        var data = JsonSerializer.Deserialize<AffixConfigData>(json, JsonOptions);
+        var data = JsonSerializer.Deserialize<AffixConfigData>(json, DataJsonOptions.Default);
         if (data == null) return;
 
         _prefixes = data.Prefixes;

--- a/Systems/CraftingSystem.cs
+++ b/Systems/CraftingSystem.cs
@@ -17,10 +17,6 @@ internal record RecipeConfigData
 /// </summary>
 public static class CraftingSystem
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
 
     /// <summary>Gets all crafting recipes currently available in the game.</summary>
     public static List<CraftingRecipe> Recipes { get; private set; } = BuildDefaultRecipes();
@@ -36,7 +32,7 @@ public static class CraftingSystem
             return;
 
         var json = File.ReadAllText(path);
-        var data = JsonSerializer.Deserialize<RecipeConfigData>(json, JsonOptions);
+        var data = JsonSerializer.Deserialize<RecipeConfigData>(json, DataJsonOptions.Default);
         if (data?.Recipes is { Count: > 0 })
             Recipes = data.Recipes;
     }

--- a/Systems/DataJsonOptions.cs
+++ b/Systems/DataJsonOptions.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+
+namespace Dungnz.Systems;
+
+/// <summary>
+/// Shared JSON serializer options for all data file loading (enemy-stats, item-stats,
+/// crafting recipes, affixes, merchant inventories). Centralizes common configuration
+/// to avoid duplication and simplify future changes.
+/// </summary>
+internal static class DataJsonOptions
+{
+    /// <summary>
+    /// Default options for deserializing game data files. Includes case-insensitive
+    /// property matching and comment support for JSON files.
+    /// </summary>
+    public static readonly JsonSerializerOptions Default = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip
+    };
+}

--- a/Systems/EnemyConfig.cs
+++ b/Systems/EnemyConfig.cs
@@ -43,11 +43,6 @@ public record EnemyStats
 /// </summary>
 public static class EnemyConfig
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip
-    };
 
     /// <summary>
     /// Reads the specified JSON file and deserialises it as a dictionary of enemy stat entries,
@@ -68,7 +63,7 @@ public static class EnemyConfig
         try
         {
             var json = File.ReadAllText(path);
-            var config = JsonSerializer.Deserialize<Dictionary<string, EnemyStats>>(json, JsonOptions);
+            var config = JsonSerializer.Deserialize<Dictionary<string, EnemyStats>>(json, DataJsonOptions.Default);
 
             if (config == null || config.Count == 0)
             {

--- a/Systems/ItemConfig.cs
+++ b/Systems/ItemConfig.cs
@@ -86,11 +86,6 @@ public record ItemConfigData
 /// </summary>
 public static class ItemConfig
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip
-    };
 
     /// <summary>
     /// Reads the specified JSON file, deserialises the item list, and validates that each entry
@@ -112,7 +107,7 @@ public static class ItemConfig
         try
         {
             var json = File.ReadAllText(path);
-            var config = JsonSerializer.Deserialize<ItemConfigData>(json, JsonOptions);
+            var config = JsonSerializer.Deserialize<ItemConfigData>(json, DataJsonOptions.Default);
 
             if (config == null || config.Items.Count == 0)
             {

--- a/Systems/MerchantInventoryConfig.cs
+++ b/Systems/MerchantInventoryConfig.cs
@@ -36,11 +36,6 @@ public record MerchantInventoryData
 /// </summary>
 public static class MerchantInventoryConfig
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip
-    };
 
     private static MerchantInventoryData? _cachedData;
 
@@ -132,7 +127,7 @@ public static class MerchantInventoryConfig
         try
         {
             var json = File.ReadAllText(path);
-            _cachedData = JsonSerializer.Deserialize<MerchantInventoryData>(json, JsonOptions);
+            _cachedData = JsonSerializer.Deserialize<MerchantInventoryData>(json, DataJsonOptions.Default);
             return _cachedData;
         }
         catch


### PR DESCRIPTION
Closes #780

Replace scattered JsonSerializerOptions instances with shared configuration.

## Changes
- Created Systems/DataJsonOptions.cs with Default options
- Removed local JsonOptions from 5 config loaders:
  - EnemyConfig
  - ItemConfig
  - CraftingSystem
  - AffixRegistry
  - MerchantInventoryConfig
- All use DataJsonOptions.Default now

Centralizes PropertyNameCaseInsensitive and ReadCommentHandling in one place.