### PR TITLE
ci: add dotnet tool manifest to pin Stryker version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.12.0",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
+    }
+  }
+}


### PR DESCRIPTION
Clean replacement for PR #767 which had stale conflicts from stacked branches. Only the dotnet-tools.json manifest file.