### PR TITLE
feat: session balance logging (#758)

### DIFF
--- a/Dungnz.Tests/SessionStatsTests.cs
+++ b/Dungnz.Tests/SessionStatsTests.cs
@@ -1,0 +1,80 @@
+using Dungnz.Systems;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Dungnz.Tests;
+
+public class SessionStatsTests
+{
+    [Fact]
+    public void SessionStats_DefaultValues_AreZero()
+    {
+        var stats = new SessionStats();
+        stats.EnemiesKilled.Should().Be(0);
+        stats.GoldEarned.Should().Be(0);
+        stats.FloorsCleared.Should().Be(0);
+        stats.BossKills.Should().Be(0);
+        stats.DamageDealt.Should().Be(0);
+    }
+
+    [Fact]
+    public void SessionStats_TracksIncrements()
+    {
+        var stats = new SessionStats();
+        stats.EnemiesKilled = 5;
+        stats.GoldEarned = 120;
+        stats.FloorsCleared = 3;
+        stats.BossKills = 1;
+        stats.DamageDealt = 350;
+
+        stats.EnemiesKilled.Should().Be(5);
+        stats.GoldEarned.Should().Be(120);
+        stats.FloorsCleared.Should().Be(3);
+        stats.BossKills.Should().Be(1);
+        stats.DamageDealt.Should().Be(350);
+    }
+
+    [Fact]
+    public void LogBalanceSummary_LogsWithoutThrowing()
+    {
+        var logger = new Mock<ILogger>();
+        var stats = new SessionStats
+        {
+            EnemiesKilled = 3,
+            GoldEarned = 50,
+            FloorsCleared = 2,
+            BossKills = 0,
+            DamageDealt = 200
+        };
+
+        var act = () => SessionLogger.LogBalanceSummary(logger.Object, stats, "Defeat");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogBalanceSummary_InvokesLogger()
+    {
+        var logger = new Mock<ILogger>();
+        logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        var stats = new SessionStats
+        {
+            EnemiesKilled = 10,
+            GoldEarned = 200,
+            FloorsCleared = 5,
+            BossKills = 2,
+            DamageDealt = 800
+        };
+
+        SessionLogger.LogBalanceSummary(logger.Object, stats, "Victory");
+
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Victory")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -24,6 +24,7 @@ public class GameLoop
     private Player _player = null!;
     private Room _currentRoom = null!;
     private RunStats _stats = null!;
+    private SessionStats _sessionStats = new();
     private DateTime _runStart;
     private Random _rng = new();
     private readonly AchievementSystem _achievements = new();
@@ -134,6 +135,7 @@ public class GameLoop
         _player = player;
         _currentRoom = startRoom;
         _stats = new RunStats();
+        _sessionStats = new SessionStats();
         _runStart = DateTime.UtcNow;
         _rng = _seed.HasValue ? new Random(_seed.Value) : new Random();
         _currentFloor = 1;
@@ -197,7 +199,7 @@ public class GameLoop
                 case CommandType.Quit:
                     _stats.FinalLevel = _player.Level;
                     _stats.TimeElapsed = DateTime.UtcNow - _runStart;
-                    RecordRunEnd(won: false);
+                    RecordRunEnd(won: false, outcomeOverride: "Quit");
                     _display.ShowMessage("Thanks for playing!");
                     return;
                 case CommandType.Descend:
@@ -348,6 +350,12 @@ public class GameLoop
             
             if (result == CombatResult.Won)
             {
+                _sessionStats.EnemiesKilled++;
+                if (_currentRoom.Enemy is Systems.Enemies.DungeonBoss
+                    || _currentRoom.Enemy is Systems.Enemies.ArchlichSovereign
+                    || _currentRoom.Enemy is Systems.Enemies.AbyssalLeviathan
+                    || _currentRoom.Enemy is Systems.Enemies.InfernalDragon)
+                    _sessionStats.BossKills++;
                 var enemyName = _currentRoom.Enemy!.Name;
                 _currentRoom.Enemy = null;
                 _display.ShowMessage(_narration.Pick(_postCombatLines, enemyName));
@@ -548,7 +556,7 @@ public class GameLoop
         _display.ShowMessage(Systems.ItemInteractionNarration.PickUp(item));
         _events?.RaiseItemPicked(_player, item, _currentRoom);
         _stats.ItemsFound++;
-        if (item.Type == ItemType.Gold) _stats.GoldCollected += item.StatModifier;
+        if (item.Type == ItemType.Gold) { _stats.GoldCollected += item.StatModifier; _sessionStats.GoldEarned += item.StatModifier; }
     }
 
     private void TakeAllItems()
@@ -576,7 +584,7 @@ public class GameLoop
             _display.ShowMessage(Systems.ItemInteractionNarration.PickUp(item));
             _events?.RaiseItemPicked(_player, item, _currentRoom);
             _stats.ItemsFound++;
-            if (item.Type == ItemType.Gold) _stats.GoldCollected += item.StatModifier;
+            if (item.Type == ItemType.Gold) { _stats.GoldCollected += item.StatModifier; _sessionStats.GoldEarned += item.StatModifier; }
             taken++;
         }
         if (taken > 0)
@@ -795,6 +803,7 @@ public class GameLoop
             _runStart = DateTime.UtcNow;
             _rng = _seed.HasValue ? new Random(_seed.Value) : new Random();
             _stats = new RunStats();
+            _sessionStats = new SessionStats();
             _display.ShowMessage($"Loaded save '{saveName}'.");
             _logger.LogInformation("Game loaded from {SaveFile}", saveName);
             _display.ShowRoom(_currentRoom);
@@ -1441,9 +1450,13 @@ public class GameLoop
     /// evaluates and displays any newly unlocked achievements. Must be called after
     /// <see cref="RunStats.FinalLevel"/> and <see cref="RunStats.TimeElapsed"/> are set.
     /// </summary>
-    private void RecordRunEnd(bool won)
+    private void RecordRunEnd(bool won, string? outcomeOverride = null)
     {
         RunStats.AppendToHistory(_stats, won);
+        _sessionStats.FloorsCleared = _currentFloor;
+        _sessionStats.DamageDealt = _stats.DamageDealt;
+        var outcome = outcomeOverride ?? (won ? "Victory" : "Defeat");
+        SessionLogger.LogBalanceSummary(_logger, _sessionStats, outcome);
         PrestigeSystem.RecordRun(won);
         if (won)
         {

--- a/Systems/SessionLogger.cs
+++ b/Systems/SessionLogger.cs
@@ -1,6 +1,7 @@
 namespace Dungnz.Systems;
 
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 /// <summary>
 /// Logs completed game sessions to a JSON-lines file for balance analysis and player
@@ -41,6 +42,32 @@ public static class SessionLogger
             var logFile = Path.Combine(logDir, "sessions.jsonl");
             var json = JsonSerializer.Serialize(record);
             File.AppendAllText(logFile, json + Environment.NewLine);
+        }
+        catch
+        {
+            // Never crash the game due to logging failure
+        }
+    }
+
+    /// <summary>
+    /// Logs a balance summary at the end of a run using the structured logger.
+    /// Captures gold earned, enemies killed, floor reached, boss kills, and damage dealt.
+    /// </summary>
+    /// <param name="logger">The logger instance to write to.</param>
+    /// <param name="sessionStats">The per-session balance metrics.</param>
+    /// <param name="outcome">The run outcome: "Victory", "Defeat", or "Quit".</param>
+    public static void LogBalanceSummary(ILogger logger, SessionStats sessionStats, string outcome)
+    {
+        try
+        {
+            logger.LogInformation(
+                "Session summary — Outcome: {Outcome}, EnemiesKilled: {EnemiesKilled}, GoldEarned: {GoldEarned}, FloorsCleared: {FloorsCleared}, BossKills: {BossKills}, DamageDealt: {DamageDealt}",
+                outcome,
+                sessionStats.EnemiesKilled,
+                sessionStats.GoldEarned,
+                sessionStats.FloorsCleared,
+                sessionStats.BossKills,
+                sessionStats.DamageDealt);
         }
         catch
         {

--- a/Systems/SessionStats.cs
+++ b/Systems/SessionStats.cs
@@ -1,0 +1,23 @@
+namespace Dungnz.Systems;
+
+/// <summary>
+/// Tracks per-session balance metrics for post-run analysis: enemies killed,
+/// gold earned, floors cleared, boss kills, and total damage dealt.
+/// </summary>
+public class SessionStats
+{
+    /// <summary>Total enemies killed during this session.</summary>
+    public int EnemiesKilled { get; set; }
+
+    /// <summary>Total gold earned (loot + room rewards) during this session.</summary>
+    public int GoldEarned { get; set; }
+
+    /// <summary>Number of dungeon floors cleared (reached the exit of).</summary>
+    public int FloorsCleared { get; set; }
+
+    /// <summary>Number of boss enemies killed during this session.</summary>
+    public int BossKills { get; set; }
+
+    /// <summary>Total damage dealt by the player to all enemies during this session.</summary>
+    public int DamageDealt { get; set; }
+}


### PR DESCRIPTION
## Session Balance Logging

Adds per-session balance tracking and structured logging for post-run analysis.

### Changes
- **SessionStats class** — tracks enemies killed, gold earned, floors cleared, boss kills, and damage dealt
- **SessionLogger.LogBalanceSummary()** — logs balance summary via ILogger at run end
- **GameLoop wiring** — increments SessionStats counters during combat and gold pickup; logs summary on victory/defeat/quit
- **4 tests** verifying SessionStats defaults, increments, and logger invocation

Closes #758