### PR TITLE
fix: add CraftingMaterial to item-stats schema enum

### DIFF
--- a/Data/schemas/item-stats.schema.json
+++ b/Data/schemas/item-stats.schema.json
@@ -11,7 +11,7 @@
         "required": ["Name", "Type"],
         "properties": {
           "Name":        { "type": "string", "minLength": 1, "maxLength": 30 },
-          "Type":        { "type": "string", "enum": ["Consumable","Weapon","Armor","Accessory","Key","Gold"] },
+          "Type":        { "type": "string", "enum": ["Consumable","Weapon","Armor","Accessory","Key","Gold","CraftingMaterial"] },
           "HealAmount":  { "type": "integer", "minimum": 0 },
           "AttackBonus": { "type": "integer", "minimum": 0 },
           "DefenseBonus":{ "type": "integer", "minimum": 0 },


### PR DESCRIPTION
## Summary
Fixes critical startup crash (#811).

`Data/schemas/item-stats.schema.json` was missing `"CraftingMaterial"` from the `Type` enum. This caused `StartupValidator` to reject 9 items in `item-stats.json` and throw before the game loop could run.

## Change
Added `"CraftingMaterial"` to the `Type` enum in the schema file — one-line fix.

## Testing
- `dotnet build` passes (0 errors)
- Game starts and reaches the main menu without exception

Closes #811