### PR TITLE
fix: correct Chest slot label spacing in GEAR display

### DIFF
--- a/Display/SpectreDisplayService.cs
+++ b/Display/SpectreDisplayService.cs
@@ -697,7 +697,7 @@ public sealed class SpectreDisplayService : IDisplayService
         AddSlot("💍 Accessory", player.EquippedAccessory, isAccessory: true);
         AddSlot("🪖 Head",      player.EquippedHead);
         AddSlot("🥋 Shoulders", player.EquippedShoulders);
-        AddSlot("🛡 Chest",     player.EquippedChest);
+        AddSlot("🛡  Chest",    player.EquippedChest);
         AddSlot("🧤 Hands",     player.EquippedHands);
         AddSlot("👖 Legs",      player.EquippedLegs);
         AddSlot("👟 Feet",      player.EquippedFeet);


### PR DESCRIPTION
Fixes Chest row misalignment in the GEAR command output.

The 🛡 emoji renders as 1 column wide (same as ⚔ and ⛨) but was only given 1 space instead of 2, causing the Chest label to appear shifted relative to all other equipment slots.

Closes #813