### PR TITLE
docs(ai-team): log armor slot icon fix session

### DIFF
--- a/.ai-team/agents/hill/history.md
+++ b/.ai-team/agents/hill/history.md
@@ -1159,3 +1159,5 @@ System.NotSupportedException: Runtime type 'Dungnz.Systems.Enemies.GoblinWarchie
 - The 🛡 (U+1F6E1), ⚔ (U+2694), and ⛨ (U+26E8) symbols are all 1-column-wide in terminals
 - They all need 2 spaces after them in slot labels to align with full-width emoji entries in the GEAR table
 - The Chest slot had only 1 space, causing its label to appear shifted relative to other equipment slots
+- All item display contexts (inventory, pickup, shop, examine, equip menu) use `ItemTypeIcon()` in `Display/SpectreDisplayService.cs`. For armor slot-awareness, the pattern is `ItemIcon(Item)` which delegates to `SlotIcon(ArmorSlot)`.
+- `ArmorSlot` enum is in `Models/ArmorSlot.cs` — values: None, Head, Shoulders, Chest, Hands, Legs, Feet, Back, OffHand

--- a/.ai-team/log/2026-03-01-armor-slot-icons.md
+++ b/.ai-team/log/2026-03-01-armor-slot-icons.md
@@ -1,0 +1,22 @@
+# Session: Armor Slot Icon Fix
+
+**Date:** 2026-03-01  
+**Requested by:** Copilot  
+**Team members:** Hill  
+
+## Work Summary
+
+**Issue:** #817  
+**PR:** #818
+
+### What Was Fixed
+Armor items were displaying a generic shield icon instead of slot-specific icons.
+
+### Implementation
+- Added `SlotIcon(ArmorSlot)` helper function
+- Added `ItemIcon(Item)` helper function
+- Updated 9 call sites to use new icon helpers
+- Inventory Type column now displays slot name for armor items
+
+### Result
+Armor icons now correctly reflect their slot type (helmet, chest, gloves, boots, etc.) instead of showing a generic shield for all armor.


### PR DESCRIPTION
Session log for armor slot icon fix (Issue #817, PR #818).

- Documented armor icon fix implementation
- Added SlotIcon(ArmorSlot) and ItemIcon(Item) helpers
- Updated 9 call sites across codebase
- Inventory Type column now displays slot name for armor