### PR TITLE
feat(startup): GameLoop.Run(GameState) overload and Program.cs startup rewire

### DIFF
--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -144,6 +144,33 @@ public class GameLoop
         _display.ShowRoom(_currentRoom);
         _currentRoom.Visited = true;
 
+        RunLoop();
+    }
+
+    /// <summary>
+    /// Starts the game loop from a previously saved GameState, restoring the player's
+    /// position, floor, seed, and all associated state.
+    /// </summary>
+    public void Run(GameState state)
+    {
+        _player = state.Player;
+        _currentRoom = state.CurrentRoom;
+        _currentFloor = state.CurrentFloor;
+        _seed = state.Seed;
+        _stats = new RunStats();
+        _sessionStats = new SessionStats();
+        _runStart = DateTime.UtcNow;
+        _rng = _seed.HasValue ? new Random(_seed.Value) : new Random();
+
+        _display.ShowMessage($"Loaded save — Floor {_currentFloor}");
+        _display.ShowRoom(_currentRoom);
+        _currentRoom.Visited = true;
+
+        RunLoop();
+    }
+
+    private void RunLoop()
+    {
         while (true)
         {
             _display.ShowCommandPrompt();

--- a/Program.cs
+++ b/Program.cs
@@ -28,21 +28,47 @@ var prestige = PrestigeSystem.Load();
 var inputReader = new ConsoleInputReader();
 IDisplayService display = new SpectreDisplayService();
 
-var intro = new IntroSequence(display, inputReader);
-var (player, actualSeed, chosenDifficulty) = intro.Run(prestige);
+var startup = new StartupOrchestrator(display, inputReader, prestige);
+var result = startup.Run();
 
-var difficultySettings = DifficultySettings.For(chosenDifficulty);
-display.ShowMessage($"Run #{prestige.TotalRuns + 1} — Seed: {actualSeed} (share to replay)");
+if (result is StartupResult.ExitGame)
+    return;
 
+// Initialize data (runs for all non-exit paths)
 EnemyFactory.Initialize("Data/enemy-stats.json", "Data/item-stats.json");
 StartupValidator.ValidateOrThrow();
 CraftingSystem.Load("Data/crafting-recipes.json");
 AffixRegistry.Load("Data/item-affixes.json");
 StatusEffectRegistry.Load("Data/status-effects.json");
 var allItems = ItemConfig.Load("Data/item-stats.json").Select(ItemConfig.CreateItem).ToList();
-var generator = new DungeonGenerator(actualSeed, allItems);
-var (startRoom, _) = generator.Generate(difficulty: difficultySettings);
 
-var combat = new CombatEngine(display, inputReader, difficulty: difficultySettings);
-var gameLoop = new GameLoop(display, combat, inputReader, seed: actualSeed, difficulty: difficultySettings, allItems: allItems, logger: loggerFactory.CreateLogger<GameLoop>());
-gameLoop.Run(player, startRoom);
+switch (result)
+{
+    case StartupResult.NewGame ng:
+    {
+        var difficultySettings = DifficultySettings.For(ng.Difficulty);
+        display.ShowMessage($"Run #{prestige.TotalRuns + 1} — Seed: {ng.Seed} (share to replay)");
+
+        var generator = new DungeonGenerator(ng.Seed, allItems);
+        var (startRoom, _) = generator.Generate(difficulty: difficultySettings);
+
+        var combat = new CombatEngine(display, inputReader, difficulty: difficultySettings);
+        var gameLoop = new GameLoop(display, combat, inputReader, seed: ng.Seed,
+            difficulty: difficultySettings, allItems: allItems,
+            logger: loggerFactory.CreateLogger<GameLoop>());
+        gameLoop.Run(ng.Player, startRoom);
+        break;
+    }
+
+    case StartupResult.LoadedGame lg:
+    {
+        var difficultySettings = DifficultySettings.For(Difficulty.Normal);
+        var combat = new CombatEngine(display, inputReader, difficulty: difficultySettings);
+        var gameLoop = new GameLoop(display, combat, inputReader, seed: lg.State.Seed,
+            difficulty: difficultySettings, allItems: allItems,
+            logger: loggerFactory.CreateLogger<GameLoop>());
+        gameLoop.Run(lg.State);
+        break;
+    }
+}
+


### PR DESCRIPTION
Implements the game loop changes and Program.cs rewire for the startup menu.

## Changes
- `GameLoop.Run(GameState)` overload — restores player/room/floor/seed from save, enters command loop
- Extracted `RunLoop()` private method to avoid duplicating command dispatch logic
- `Program.cs` rewired to use `StartupOrchestrator` (from Hill's PR #835/#837)

Closes #836

Related: #835/#837 (Hill's PR — must merge first or together), #838 (Romanoff's tests)

Note: This PR references types from Hill's branch. Merge after Hill's PR or merge together.