### PR TITLE
docs(ai-team): log startup menu session (2026-03-02)

### DIFF
--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -15338,3 +15338,104 @@ All emoji and icon characters used throughout the game (equipment slots, combat 
 ## Rationale
 
 Mixed character sets cause terminal column width discrepancies between Spectre.Console's cell measurement and actual terminal rendering, producing persistent border and text alignment bugs that are difficult to fix case-by-case.
+
+---
+
+# Decision: Startup Menu Architecture
+
+**Date:** 2026-03-02  
+**Agent:** Coulson
+
+## Decision
+
+Implement a startup menu system shown before `IntroSequence`, offering: **New Game**, **Load Save**, **New Game with Seed**, and **Exit**. The design uses:
+
+- **StartupMenuOption** enum — discriminator for user choice
+- **StartupResult** discriminated union — outcome (NewGame, LoadedGame, ExitGame)
+- **StartupOrchestrator** class — coordinates the menu flow
+- Three new **IDisplayService** methods:
+  - `ShowStartupMenu(bool hasSaves)` — main menu
+  - `SelectSaveToLoad(string[] saveNames)` — save picker
+  - `int? ReadSeed()` — seed input with 6-digit validation
+- **GameLoop.Run(GameState)** overload — load saved game without dungeon generation
+- **Program.cs** rewrite — branch on `StartupResult` to dispatch to new game or loaded game flow
+
+## Implementation Notes
+
+- **RunLoop() extraction:** Both `Run(Player, Room)` and `Run(GameState)` share a common command loop extracted to private `RunLoop()` method to avoid duplication.
+- **IntroSequence.showTitle parameter:** Optional parameter (default `true`) skips title display when called from orchestrator, which already shows it.
+- **Load error handling:** `RunLoadSave()` catches exceptions and displays errors via `_display.ShowError()`, re-showing menu on cancel.
+- **Seed validation:** Accepts 6-digit numeric seeds (100000–999999) with retry on invalid input.
+
+## Rationale
+
+- Keeps changes surgical — one new class, three new interface methods, one `GameLoop` overload.
+- Orchestrator owns the loop, so cancelling a sub-menu (save picker, seed entry) naturally re-shows the startup menu.
+- Pattern matching on `StartupResult` in `Program.cs` makes the branching logic clean and type-safe.
+- Reuses existing `IntroSequence` for name/class/difficulty flow; only the seed entry point differs.
+
+---
+
+# Decision: GameLoop.Run(GameState) and Program.cs Rewire
+
+**Date:** 2026-03-02  
+**Agent:** Barton
+
+## Decision
+
+Implemented the game loop changes required for startup menu feature:
+
+1. **GameLoop.cs** — Added public `Run(GameState)` overload that restores player, room, floor, and seed from a saved state and enters the command loop.
+2. **GameLoop.cs** — Extracted the `while (true) { ... }` command dispatch switch into a private `RunLoop()` method.
+3. **Program.cs** — Rewired to use `StartupOrchestrator`, pattern-match on `StartupResult`, and dispatch:
+   - `NewGame` → dungeon generation + `Run(Player, Room)`
+   - `LoadedGame` → `Run(GameState)`
+   - `ExitGame` → exit application
+
+## Implementation Notes
+
+- **Minimal state initialization:** `Run(GameState)` resets stats and session tracking to new instances, treating the load as a new session.
+- **Shared command loop:** Both `Run()` overloads call `RunLoop()` after state setup, ensuring identical command dispatch logic and maintaining DRY.
+- **Different welcome messages:** New game shows difficulty and floor separately; loaded game shows "Loaded save — Floor N".
+
+## Rationale
+
+- Avoids duplicating ~60-line command loop logic between two `Run()` overloads.
+- Clean separation of concerns: new game initializes dungeon; loaded game restores from save.
+- Depends on Hill's PR for `StartupOrchestrator`, `StartupResult`, and `StartupMenuOption` types.
+
+---
+
+# Decision: Startup Menu UI Implementation
+
+**Date:** 2026-03-02  
+**Agent:** Hill
+
+## Decision
+
+Implemented the complete display layer for startup menu system per Coulson's design:
+
+### New Files
+- **Engine/StartupMenuOption.cs** — Enum with NewGame, LoadSave, NewGameWithSeed, Exit
+- **Engine/StartupResult.cs** — Sealed record hierarchy (NewGame, LoadedGame, ExitGame)
+- **Engine/StartupOrchestrator.cs** — Main orchestrator class
+
+### Modified Files
+- **Display/IDisplayService.cs** — Added three new methods as specified
+- **Display/SpectreDisplayService.cs** — Implemented all three methods with Spectre-specific UI
+- **Display/DisplayService.cs (ConsoleDisplayService)** — Implemented all three methods using Console.ReadLine fallback
+- **Engine/IntroSequence.cs** — Added optional `showTitle = true` parameter
+
+## Implementation Details
+
+- **ShowStartupMenu:** Uses `PromptFromMenu` with conditional inclusion of Load Save option (omitted when `hasSaves` is false).
+- **SelectSaveToLoad:** Maps save names to menu options with Back/cancel option returning `null`.
+- **ReadSeed:** Validates 6-digit numeric range (100000–999999) with retry loop and "cancel" option.
+- **Both display implementations:** Required implementations in both `SpectreDisplayService` and legacy `ConsoleDisplayService` to satisfy interface contract.
+
+## Rationale
+
+- 100% adherence to Coulson's architecture design ensures integration compatibility with Barton's Program.cs rewire.
+- Dual display implementations maintain backward compatibility with legacy console code.
+- XML documentation on enum members satisfies project's documentation requirements (CS1591).
+- Adding optional parameter to `IntroSequence.Run()` with default `true` preserves existing call sites while enabling title suppression from orchestrator.

--- a/.ai-team/log/2026-03-02-startup-menu.md
+++ b/.ai-team/log/2026-03-02-startup-menu.md
@@ -1,0 +1,71 @@
+# 2026-03-02 Session: Startup Menu Implementation
+
+**Requested by:** Anthony (Boss)
+
+## Feature
+Startup menu with New Game / Load Save / Enter Seed / Exit options
+
+## GitHub Issues Created
+- #835 — Startup menu UI
+- #836 — Load save functionality
+- #837 — Seed entry
+- #838 — Tests
+
+## Team Work Summary
+
+### Architecture (Coulson)
+Designed the startup menu system:
+- **StartupMenuOption** enum (NewGame, LoadSave, NewGameWithSeed, Exit)
+- **StartupResult** discriminated union (NewGame, LoadedGame, ExitGame)
+- **StartupOrchestrator** class — coordinates menu flow
+- Three new **IDisplayService** methods:
+  - `ShowStartupMenu(bool hasSaves)`
+  - `SelectSaveToLoad(string[] saveNames)`
+  - `int? ReadSeed()`
+- **GameLoop.Run(GameState)** overload for loading saves
+- **Program.cs** rewire to use orchestrator
+
+### Implementation (Hill)
+Implemented display layer and orchestrator per Coulson's design on **PR #840**:
+- **New files:**
+  - `Engine/StartupMenuOption.cs` — Enum
+  - `Engine/StartupResult.cs` — Discriminated union records
+  - `Engine/StartupOrchestrator.cs` — Main orchestrator class
+- **Modified files:**
+  - `Display/IDisplayService.cs` — Added 3 new methods
+  - `Display/SpectreDisplayService.cs` — Implemented 3 methods
+  - `Display/DisplayService.cs` (ConsoleDisplayService) — Implemented 3 methods
+  - `Engine/IntroSequence.cs` — Added optional `showTitle` parameter
+- **Design adherence:** 100% per Coulson's design doc
+- **Build:** ✅ Passes, PR #840 merged to master
+
+### GameLoop & Program (Barton)
+Implemented game loop changes and Program.cs rewire:
+- **GameLoop.cs:**
+  - Added `Run(GameState)` overload — restores player, room, floor, seed from saved state
+  - Extracted `RunLoop()` method — shared command loop for both entry paths
+- **Program.cs:**
+  - Integrated `StartupOrchestrator` call
+  - Pattern-matched on `StartupResult` to branch:
+    - `NewGame` → dungeon generation + `Run(Player, Room)`
+    - `LoadedGame` → restore and `Run(GameState)`
+    - `ExitGame` → exit application
+- **PR #839:** Closed as superseded — Hill included identical changes in PR #840
+- **Design adherence:** 100% per Coulson's design
+
+### Tests (Romanoff)
+Writing unit tests on **PR #838** (in progress):
+- `StartupOrchestratorTests.cs` — Menu flow, save load, seed entry, cancel paths
+- `TestDisplayService` — Stubs for 3 new methods
+- Coverage: orchestrator with `TestDisplayService`, GameLoop loaded-state overload, seed validation edge cases
+
+## Build Status
+✅ **Master at commit 10ee689: Build passing**
+- PR #840 merged successfully
+- All architecture and UI layer complete
+- Tests in progress on PR #838
+
+## Decision Documents
+- `coulson-startup-menu-architecture.md` — Design spec
+- `barton-startup-gameloop.md` — GameLoop implementation
+- `hill-startup-menu-implementation.md` — Display layer implementation


### PR DESCRIPTION
Log session work on startup menu feature (issues #835-#838).

## Changes
- Session log: 2026-03-02-startup-menu.md
- Merge decision documents from inbox (coulson, barton, hill designs)
- Delete inbox files after merge

## Details
- Coulson: Architecture design
- Hill: Display layer implementation (PR #840 merged)
- Barton: GameLoop and Program.cs rewire (PR #839 superseded by Hill's PR)
- Romanoff: Writing tests on PR #838

Build verified passing at commit 10ee689.