### PR TITLE
docs(ai-team): log skill tree menu session (2026-03-03)

### DIFF
--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -15592,3 +15592,36 @@ Added 4 missing property definitions to the schema:
 - PR: https://github.com/AnthonyMFuller/Dungnz/pull/850
 - Merged to: master (squashed)
 - Commit: 3c1a8a2
+
+---
+
+# Decision: Always Escape Literal Brackets in Spectre.Console Strings
+
+**Date:** 2025-07-01  
+**Author:** Hill
+
+## Pattern
+
+When passing any user-facing string to Spectre.Console APIs (`MarkupLine`, `table.AddRow`, etc.), any literal `[` or `]` characters must be escaped — otherwise Spectre interprets them as markup tags and throws `InvalidOperationException`.
+
+## Escape Convention
+
+Use Spectre's double-bracket convention in string literals:
+- `[` → `[[`
+- `]` → `]]`
+
+Or wrap dynamic strings in `Markup.Escape(str)`.
+
+## When This Applies
+
+- Command syntax strings in help text (e.g., `"go [[north|south|east|west]]"`)
+- Any dynamic content that might contain brackets (e.g., item names, player input echoes)
+- Table rows, panel content, markup lines
+
+## What NOT to Escape
+
+Intentional Spectre markup tags like `[bold]`, `[red]`, `[grey]...[/]` should never be escaped — these are the valid markup syntax.
+
+## Reference
+
+Fixed in PR #854 (issue #853) — `ShowHelp()` in `Display/SpectreDisplayService.cs`.

--- a/.ai-team/log/2026-03-03-skill-tree-menu.md
+++ b/.ai-team/log/2026-03-03-skill-tree-menu.md
@@ -1,0 +1,38 @@
+# Session: 2026-03-03 — Skill Tree Menu Implementation
+
+**Requested by:** Boss (Anthony)
+
+## Summary
+Implemented interactive skill tree menu interface with proper class filtering and menu selection.
+
+## Team Contributions
+
+### Hill
+- Implemented `ShowSkillTreeMenu()` in `SpectreDisplayService` and interface `IDisplayService`
+
+### Barton
+- Updated `HandleSkills()` in `GameLoop.cs` to use the new menu system
+- Added `GetSkillsForClass()` helper to `SkillTree.cs` for class-based filtering
+- Added `HandleLearnSpecificSkill()` helper method
+
+## Issues & PRs
+
+| Item | Type | Status | Details |
+|------|------|--------|---------|
+| #855 | Issue | Closed | Interactive skill tree menu selection |
+| #856 | Issue | Closed | Class-based skill filtering |
+| #857 | PR | Merged | Skill tree menu implementation (merged to master) |
+
+## Test Results
+
+| Branch | Failures | Status |
+|--------|----------|--------|
+| master (before) | 7 | 🔴 baseline |
+| feature branch | 6 | 🟢 improved |
+
+1 test failure resolved in this session.
+
+## Commits
+
+- Feature branch: feature/skill-tree-menu
+- Target: master


### PR DESCRIPTION
## Scribe Session Log

Logged session: 2026-03-03-skill-tree-menu

### Changes
- Created session log entry (.ai-team/log/2026-03-03-skill-tree-menu.md)
- Merged decision from inbox: Always Escape Literal Brackets in Spectre.Console Strings

### Details
- Requested by: Boss (Anthony)
- Feature implemented: Interactive skill tree menu with class filtering
- Issues closed: #855, #856
- PR merged: #857
- Test improvement: 7 failures → 6 failures