### PR TITLE
docs(ai-team): retrospective 2026-03-03 — decisions and session log

### DIFF
--- a/.ai-team/agents/coulson/history.md
+++ b/.ai-team/agents/coulson/history.md
@@ -2222,3 +2222,47 @@ Both PRs reviewed and merged in Round 3 (see below).
 - Romanoff's tests on separate branch (`squad/846-inspect-compare-tests`) ensure feature coverage without code duplication
 - PR history: feat commit (88a4476) + docs (c46050e) + tests (5620c9c) — logically separated, clean squash
 - All error cases properly handled; no edge cases missed
+
+
+---
+
+### 2026-03-03: Team Retrospective — Post-Phase Review
+
+**Context:** Facilitated full team retrospective covering emoji/icon alignment, startup menu, inspect/compare, skill tree, HELP crash fix, and test suite restoration (6 failures → 0, 1420 passing).
+
+**Key Themes Identified:**
+
+1. **God Classes are consensus #1 debt** — Hill and Barton independently flagged `GameLoop.cs` (1,635 lines) and `CombatEngine.cs` (1,200+ lines) as unsustainable. Both recommend decomposition via handler/processor patterns.
+
+2. **Content exists but is not surfaced** — Fury noted item descriptions, lore, and tooltips are written but invisible. The Inspect & Compare feature is a model for fixing this pattern.
+
+3. **Test coverage clusters away from display code** — Romanoff identified `DisplayService.cs` at 39.6% coverage, `ConsoleMenuNavigator.cs` at 0%. The hardest-to-test code is the least tested.
+
+4. **Incomplete systems create silent bugs** — 5 unwired affix properties, missing `UndyingWill` passive, placeholder boss name. Features that look done but have gaps.
+
+**Decisions Proposed:**
+- D1: Command Handler Pattern for GameLoop decomposition
+- D2: Passive Effect Registry Pattern for combat passives
+- D3: Display Method Smoke Test Requirement
+- D4: Release Tag Must Include Commit SHA
+- D5: Enemy Data Must Include Lore Field
+
+**Action Items Generated:** 17 total across P0/P1/P2 priorities
+
+**Team Dynamics Observed:**
+- Hill and Coulson aligned on architecture decomposition priorities
+- Barton ready to consolidate passive systems he owns
+- Romanoff has clear visibility into coverage gaps with practical solutions
+- Fury's content work is mature; gap is surfacing it to players
+- Fitz has solid DevOps foundation with small reliability edge cases to fix
+
+**Learnings for Future Ceremonies:**
+- Parallel sub-task spawning (3 at a time) works well for gathering independent input
+- Team members give more specific feedback when provided with concrete recent work context
+- Top Improvement Pick format forces prioritization — everyone must choose ONE thing
+- Cross-functional perspectives surface issues no single role would identify
+
+**Artifacts:**
+- `.ai-team/log/2026-03-03-retrospective.md` — Full ceremony summary
+- `.ai-team/decisions/inbox/coulson-retrospective-2026-03-03.md` — 5 proposed decisions
+

--- a/.ai-team/ceremonies.md
+++ b/.ai-team/ceremonies.md
@@ -33,7 +33,8 @@
 **Agenda:**
 1. What went well?
 2. What could be improved?
-3. Action items for next iteration
+3. **What single change or addition do you think would most improve the solution?** (each member answers)
+4. Action items for next iteration
 
 ---
 

--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -15625,3 +15625,132 @@ Intentional Spectre markup tags like `[bold]`, `[red]`, `[grey]...[/]` should ne
 ## Reference
 
 Fixed in PR #854 (issue #853) — `ShowHelp()` in `Display/SpectreDisplayService.cs`.
+
+---
+
+# Retrospective Decisions — 2026-03-03
+
+**Author:** Coulson  
+**Source:** Team Retrospective  
+**Date:** 2026-03-03
+
+---
+
+## Decision: Command Handler Pattern for GameLoop Decomposition
+
+**Status:** Proposed
+
+**Decision:**
+Adopt `ICommandHandler` as the standard pattern for all GameLoop command handling. New commands MUST be implemented as separate handler classes registered in a `Dictionary<CommandType, ICommandHandler>`. Existing `Handle*` methods should be extracted during normal churn.
+
+**Interface:**
+```csharp
+public interface ICommandHandler
+{
+    bool CanHandle(CommandType command);
+    void Handle(GameContext ctx);
+}
+```
+
+**Rationale:**
+- `GameLoop.cs` is 1,635 lines and growing with every feature
+- Each handler becomes independently unit-testable
+- Enables architecture tests to enforce layer boundaries per handler
+- Makes onboarding contributors dramatically easier
+
+**Proposed by:** Hill, Coulson
+
+---
+
+## Decision: Passive Effect Registry Pattern
+
+**Status:** Proposed
+
+**Decision:**
+Consolidate all passive effect implementations behind an `IPassiveEffect` interface with a central registry. Replace raw string `PassiveEffectId` with validated enum or registry key.
+
+**Interface:**
+```csharp
+public interface IPassiveEffect
+{
+    PassiveEffectId Id { get; }
+    PassiveTrigger Trigger { get; } // OnHit, OnTakeDamage, OnKill, OnCombatStart, OnWouldDie
+    void Apply(CombatContext context);
+}
+```
+
+**Rationale:**
+- Passives currently scattered across `PassiveEffectProcessor`, `SoulHarvestPassive`, and `SkillTree`
+- Raw string IDs allow typos that wire to nothing with no diagnostic
+- `UndyingWill` TODO has been open since Phase 4 — Warrior class ships with documented hole
+- Unified registry makes every future passive follow same pattern
+
+**Proposed by:** Barton
+
+---
+
+## Decision: Display Method Smoke Test Requirement
+
+**Status:** Proposed
+
+**Decision:**
+All `IDisplayService` methods that render Spectre.Console markup MUST have at least one smoke test that:
+1. Instantiates real `SpectreDisplayService` against captured `AnsiConsoleOutput`
+2. Calls the method with representative inputs
+3. Asserts no `MarkupException` is thrown
+4. Asserts no unescaped `[` characters in markup context
+
+**Rationale:**
+- `DisplayService.cs` is at 39.6% line coverage
+- HELP crash shipped without regression test catching it
+- All recent display bugs (alignment, markup, emoji) were caught manually, not by tests
+- Spectre provides `AnsiConsoleOutput` specifically for this pattern
+
+**Proposed by:** Romanoff
+
+---
+
+## Decision: Release Tag Must Include Commit SHA
+
+**Status:** Proposed
+
+**Decision:**
+Release tags MUST include commit SHA suffix to ensure every merge produces a unique release.
+
+**Format:** `v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)`
+
+**Rationale:**
+- Current date-only format silently skips second release when two PRs merge same day
+- No error, no warning — pipeline looks green but nothing shipped
+- SHA suffix adds auditability while keeping human-readable dates
+
+**Proposed by:** Fitz
+
+---
+
+## Decision: Enemy Data Must Include Lore Field
+
+**Status:** Proposed
+
+**Decision:**
+All enemy entries in `enemy-stats.json` MUST include a `Lore` field with at least two sentences describing what the enemy is, why it exists, and/or its behavior.
+
+**Rationale:**
+- 31 enemies currently have zero lore in data layer
+- One Bestiary or INSPECT-enemy feature away from shipping empty descriptions
+- Lore transforms stat checks into story beats for players
+- Architecture cost is trivial (one JSON field)
+
+**Proposed by:** Fury
+
+---
+
+## Retrospective Summary
+
+These five decisions emerged from the 2026-03-03 team retrospective. Each addresses a recurring theme:
+- **D1, D2:** God Class decomposition (`GameLoop`, scattered effects)
+- **D3:** Test coverage in hard-to-test display code
+- **D4:** Delivery reliability edge case (release tagging)
+- **D5:** Content surfacing gap (enemy lore)
+
+All are marked **Proposed** pending team review and formal adoption.

--- a/.ai-team/log/2026-03-03-retrospective-session.md
+++ b/.ai-team/log/2026-03-03-retrospective-session.md
@@ -1,0 +1,54 @@
+# Retrospective Session Log — 2026-03-03
+
+**Requested by:** Anthony (Boss)
+
+**Facilitator:** Coulson (full team retrospective — all 6 members)
+
+---
+
+## Session Summary
+
+Team retrospective covering the past sprint cycle. Agenda included what went well, areas for improvement, and prioritized action items.
+
+---
+
+## Outcomes
+
+- **Participants:** 6 team members
+- **Total Action Items:** 16 (covering P0–P2 priorities)
+
+---
+
+## Key Themes
+
+1. **GameLoop God Class:** Multiple members flagged `GameLoop.cs` (1,635 lines) as becoming unwieldy. Proposed command handler pattern for decomposition.
+
+2. **Passive Effect Consolidation:** Passive effects scattered across multiple systems with raw string IDs prone to typos. Registry pattern proposed to unify implementation.
+
+3. **Display Test Coverage Gaps:** `DisplayService.cs` at 39.6% coverage. Recent crashes and bugs not caught by tests. Smoke test requirement proposed.
+
+4. **Enemy Lore Content:** 31 enemies lack lore data. Upcoming features (Bestiary, INSPECT) will expose this gap. Lore field requirement proposed.
+
+---
+
+## Decisions Produced
+
+See `.ai-team/decisions/inbox/coulson-retrospective-2026-03-03.md` for full decision record.
+
+Five decisions emerged:
+- **D1:** Command Handler Pattern for GameLoop Decomposition (Proposed)
+- **D2:** Passive Effect Registry Pattern (Proposed)
+- **D3:** Display Method Smoke Test Requirement (Proposed)
+- **D4:** Release Tag Must Include Commit SHA (Proposed)
+- **D5:** Enemy Data Must Include Lore Field (Proposed)
+
+---
+
+## Next Steps
+
+All decisions marked Proposed pending formal team review and adoption.
+
+---
+
+**Logged by:** Scribe  
+**Date:** 2026-03-03

--- a/.ai-team/log/2026-03-03-retrospective.md
+++ b/.ai-team/log/2026-03-03-retrospective.md
@@ -1,0 +1,135 @@
+# Retrospective — 2026-03-03
+**Facilitator:** Coulson
+**Participants:** Coulson, Hill, Barton, Romanoff, Fury, Fitz
+**Context:** Post-phase retrospective covering emoji/icon work, startup menu, inspect/compare, skill tree, help crash fix, test suite restoration
+
+---
+
+## What Went Well
+
+### Test Suite & Quality
+- **Romanoff:** 1420 tests green after inheriting 6 failures. Architecture tests now gate `JsonDerivedType` registration and layer violations on every CI run — the kind of silent save-corruption bug that would have hit production is now permanently blocked.
+- **Fitz:** CI is green and *meaningful* — the 80% coverage threshold enforced in both CI and locally via `scripts/coverage.sh` keeps discipline without manual review.
+- **Coulson:** The test infrastructure investment from earlier sprints paid dividends. We fixed 6 failures across architecture violations, JSON serialization gaps, and test isolation races without touching feature code.
+
+### Architecture & Interface Design
+- **Hill:** The `IDisplayService` / `SpectreDisplayService` separation is proven. Startup menu, skill tree, inspect/compare, and interactive inventory selection all shipped without touching test stub core behavior.
+- **Barton:** The Skill Tree menu hooks into the existing `SkillTree` system without model changes — interface segregation paid off.
+- **Coulson:** Contract-first design continues to prevent integration issues during parallel development.
+
+### Display & Polish
+- **Fury:** Emoji/icon standardization eliminated a silent immersion-killer. Misaligned characters broke the "polished dungeon crawler" feel before players read a single word.
+- **Hill:** The EAW-compatible alignment work is fit-and-finish detail that makes a console game feel considered rather than hacked together.
+- **Romanoff:** Alignment regression tests (`AlignmentRegressionTests`, `ShowEquipmentComparisonAlignmentTests`) strip ANSI codes and verify visual width — surgical precision over broad snapshots.
+
+### Feature Delivery
+- **Hill:** Startup flow cohesion — `StartupOrchestrator`, `StartupMenuOption`, `StartupResult` are clean, named types. Seed entry integrating with save selection was well-scoped.
+- **Fury:** Inspect & Compare finally surfaces item descriptions to players. Content investment is getting its ROI.
+- **Barton:** Save/startup integration is solid — non-trivial feature surface that shipped working.
+
+### DevOps & Pipeline
+- **Fitz:** Release pipeline auto-publishes self-contained binaries for `linux-x64` and `win-x64` with auto-generated release notes. Zero-friction shipping. Defence-in-depth security with CodeQL, RNG audit, JSON schema validation, and Dependabot.
+
+---
+
+## What Could Be Improved
+
+### Code Structure
+- **Hill:** `GameLoop.cs` is a 1,635-line God Class. Every new command gets bolted on as another private method. No structure — dungeon events, save/load, combat dispatch, shop logic all in one file. **Biggest maintenance liability.**
+- **Hill:** `IDisplayService` violates Interface Segregation — 40+ methods, test stubs must implement everything even when testing one feature.
+- **Barton:** `CombatEngine.cs` is 1200+ lines: damage calculation, ability dispatch, narration, XP, level-up, passive triggers, cooldown lifecycle, flee logic — all one file. Merge conflict factory.
+
+### Incomplete Systems
+- **Barton:** 5 affix properties are defined but completely unwired: `EnemyDefReduction`, `HolyDamageVsUndead`, `BlockChanceBonus`, `ReviveCooldownBonus`, `PeriodicDmgBonus`. Players can roll items with these affixes and get nothing. Silent gameplay bug.
+- **Barton:** Class passives are scattered across three places (`PassiveEffectProcessor`, `SoulHarvestPassive`, `SkillTree`). `UndyingWill` TODO has been sitting since Phase 4 — Warrior class ships with a documented hole.
+- **Barton:** Only 2 enemies out of 29+ have custom `IEnemyAI` implementations. Boss phases are inconsistent. Enemy count and behavior depth are out of proportion.
+
+### Test Coverage Gaps
+- **Romanoff:** `DisplayService.cs` at 39.6% line coverage — the display layer where alignment, markup, and emoji bugs live is less than 40% covered.
+- **Romanoff:** `GameLoop.cs` at 50% coverage. Central command dispatch is half dark.
+- **Romanoff:** The HELP crash fix has zero regression test. If someone touches that code path again, CI won't catch it.
+- **Romanoff:** `ConsoleMenuNavigator.cs` at 0% coverage. Spectre.Console menu driver is completely untested.
+
+### Content Gaps
+- **Fury:** All 31 enemies are missing `Lore` field in data layer. One Bestiary or INSPECT-enemy feature away from shipping empty descriptions.
+- **Fury:** Skill tooltips read like patch notes (`"+15% damage on attacks"`). Players see these in Skill Tree menu — they're reading a spreadsheet, not a game.
+- **Fury:** "Dungeon Boss" is a placeholder name masquerading as a final encounter.
+- **Fury:** Merchant has no personality — functionally anonymous despite `MerchantNarration.cs` existing.
+
+### DevOps Gaps
+- **Fitz:** Date-based versioning means if two PRs merge same day, second release is silently skipped. No error, no notice.
+- **Fitz:** No macOS artifact in release pipeline.
+- **Fitz:** Mutation testing threshold at 50% is too forgiving with 1420 tests and 80% line coverage.
+- **Fitz:** Coverage results aren't surfaced on PRs — developers can't see which lines are uncovered without running locally.
+
+### Data Quality
+- **Hill:** `JsonDerivedType` discriminator casing is inconsistent (PascalCase vs lowercase). Latent save-file bug.
+- **Hill:** `__TAKE_ALL__` sentinel string in `IDisplayService` is an implementation detail leaking into public interface.
+- **Barton:** `PassiveEffectId` is a raw string — one typo wires to nothing with no diagnostic.
+
+---
+
+## Top Improvement Picks (per member)
+
+| Member | Role | Their #1 Improvement Pick |
+|--------|------|--------------------------|
+| Coulson | Lead | **Extract command handlers from GameLoop** — introduce `ICommandHandler` pattern to decompose the 1,635-line God Class. Each command becomes independently testable. Unblocks architecture enforcement. |
+| Hill | C# Dev | **Decompose GameLoop using command handler pattern** — `ICommandHandler` interface, extract `Handle*` methods into separate classes, register in `Dictionary<CommandType, ICommandHandler>`. Refactor, not rewrite. |
+| Barton | Systems Dev | **Unify class passives into `IPassiveEffect` registry and close `UndyingWill` TODO** — define interface with `PassiveEffectId`, `Trigger` enum, `Apply(CombatContext)`. Replace raw strings. Close the Warrior class hole. |
+| Romanoff | Tester | **Add Spectre markup rendering smoke test layer for DisplayService** — capture `AnsiConsole` output, assert no `MarkupException`, assert no unescaped brackets. Would have caught HELP crash. Lifts coverage from 39.6%. |
+| Fury | Content Writer | **Add `Lore` fields to all 31 enemies in enemy-stats.json** — two-sentence entries that transform stat checks into story beats. Architecture trivial, impact immediate. |
+| Fitz | DevOps | **Fix date-based versioning to support multiple releases per day** — append short commit SHA to tag: `v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)`. Every merge reliably produces a release. |
+
+---
+
+## Action Items
+
+| Owner | Action | Priority |
+|-------|--------|----------|
+| Hill + Coulson | Create ticket: Decompose `GameLoop` into `ICommandHandler` implementations | P0 |
+| Barton | Create `IPassiveEffect` interface and registry, close `UndyingWill` TODO | P0 |
+| Romanoff | Add Spectre markup crash regression test for HELP command | P0 |
+| Fury | Add `Lore` field to all 31 enemies in `enemy-stats.json` | P0 |
+| Fitz | Fix `squad-release.yml` tag to include commit SHA suffix | P0 |
+| Barton | Audit and wire/remove 5 unwired affix properties | P1 |
+| Hill | Fix `JsonDerivedType` discriminator casing inconsistency, add round-trip test | P1 |
+| Romanoff | Create `DisplayService` smoke test suite using `AnsiConsoleOutput` capture | P1 |
+| Fitz | Add `osx-x64` publish step to release pipeline | P1 |
+| Fitz | Raise Stryker `--threshold-break` from 50 to 65 | P1 |
+| Romanoff | Add coverage floor assertion to CI (78% threshold with headroom) | P1 |
+| Fury | Write player-facing tooltip strings for all skills in Skill Tree | P2 |
+| Fury | Give Dungeon Boss a real name and dedicated lore | P2 |
+| Hill | Create proper return type for `ShowTakeMenuAndSelect`, remove `__TAKE_ALL__` sentinel | P2 |
+| Barton | Add `IEnemyAI` implementations for top-tier bosses (Infernal Dragon, Lich) | P2 |
+| Fitz | Upload coverage XML as CI artifact, add HTML summary generation | P2 |
+| Romanoff | Propose test file naming convention, migrate during normal churn | P2 |
+
+---
+
+## Notes
+
+### Recurring Themes
+1. **God Classes are the #1 technical debt** — both Hill and Barton independently identified their respective domains (`GameLoop.cs`, `CombatEngine.cs`) as unsustainable. The team consensus is clear: decomposition is overdue.
+
+2. **Content exists but isn't surfaced** — Fury noted that descriptions, lore, and tooltips are written but invisible to players. The Inspect & Compare feature is a model for how to fix this.
+
+3. **Test coverage gaps cluster in display/UI code** — Romanoff's analysis shows the hardest-to-test code (Spectre.Console integration) is also the least tested. The team needs a strategy for rendering tests.
+
+4. **Incomplete systems create silent bugs** — unwired affixes, missing passives, placeholder boss names — features that *look* done but have gaps players will eventually find.
+
+### Risks
+- **P0 items are all foundational** — if we don't decompose GameLoop soon, every new command makes the problem worse.
+- **The HELP crash pattern could recur** — any Spectre markup rendering bug will ship to players with current test coverage.
+- **Date-versioning gap** means active sprint days could silently skip releases.
+
+### Team Dynamics
+- Hill and Coulson are aligned on command handler pattern as the path forward.
+- Barton owns combat and passive systems and is ready to consolidate them.
+- Romanoff has clear visibility into coverage gaps and practical solutions.
+- Fury's content work is mature; the gap is surfacing it to players.
+- Fitz has defense-in-depth DevOps but needs small fixes for reliability edge cases.
+
+### Decision Candidates for Inbox
+1. **Command Handler Pattern** — adopt `ICommandHandler` as standard pattern for new commands
+2. **Passive Effect Registry** — standardize `IPassiveEffect` interface for all passive behaviors
+3. **Display Smoke Tests** — require Spectre rendering coverage for display methods


### PR DESCRIPTION
Requested by: Anthony (Boss)

Changes:
- Added retrospective session log (all 6 members, 16 action items)
- Merged retrospective decisions from inbox (5 decisions)
- Updated Coulson history

Key themes:
- GameLoop God Class decomposition
- Passive effect consolidation
- Display test coverage gaps
- Enemy lore content

Ready for review by Coulson.