### PR TITLE
fix: append git SHA to release tag to support same-day releases (#874)

### DIFF
--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -19,7 +19,8 @@ jobs:
         id: version
         run: |
           VERSION=$(git describe --tags --always | sed 's/^v//')
-          TAG="v$(date +%Y.%m.%d)"
+          # Append short SHA so multiple merges on the same day each get a unique tag.
+          TAG="v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "📦 Version: $VERSION (tag: $TAG)"
@@ -27,9 +28,12 @@ jobs:
       - name: Check if tag already exists
         id: check_tag
         run: |
+          # SHA-suffixed tags are unique per commit, so this guard only fires when
+          # the exact same commit is re-pushed (e.g. a forced push) — preventing a
+          # duplicate release without silently skipping a legitimate new merge.
           if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️ Tag ${{ steps.version.outputs.tag }} already exists — skipping release."
+            echo "⏭️ Tag ${{ steps.version.outputs.tag }} already exists — same commit re-pushed, skipping release."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "🆕 Tag ${{ steps.version.outputs.tag }} does not exist — creating release."


### PR DESCRIPTION
## Problem

`squad-release.yml` generated tags as `v$(date +%Y.%m.%d)`. A second PR merging on the same day silently skipped the release because the tag already existed.

## Fix

The `Generate version tag` step now uses:
```bash
TAG="v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
```

Every merge to master now produces a unique, traceable tag (e.g. `v2025.07.15-9e03b12`).

## Tag-existence check

Kept as-is — it now guards only against re-releasing when the **same commit** is force-pushed, rather than masking legitimate same-day merges. Updated comments explain the new semantics.

## Checklist
- [x] Artifact names unchanged (`dungnz-linux-x64.zip`, `dungnz-win-x64.zip`)
- [x] No osx-x64 added (tracked in #876)
- [x] YAML validated

Closes #874