### PR TITLE
ci: osx-x64 target, Stryker threshold, coverage floor

### DIFF
--- a/.ai-team/agents/fitz/history.md
+++ b/.ai-team/agents/fitz/history.md
@@ -206,3 +206,31 @@ Implemented six CI/CD and infrastructure enhancements across multiple PRs:
 - `.config/dotnet-tools.json` — new file
 
 **Impact:** Faster CI builds, automated dependency management, consistent formatting, downloadable releases, reproducible testing, and security analysis.
+
+---
+
+### CI Improvements — Issues #876 #877 #878 (March 2026)
+
+**Branch:** `squad/876-877-878-ci-improvements`
+
+**#876 — osx-x64 publish target:**
+- Added `Publish osx-x64` step to `squad-release.yml` (alongside existing linux-x64 and win-x64)
+- Archives to `dungnz-osx-x64.zip` and attaches to GitHub Release
+
+**#877 — Stryker threshold raise:**
+- Could not run Stryker live (schedule-only workflow, takes 30+ minutes)
+- Previous threshold-break: 50. Raised to 65.
+- threshold-low raised 65 → 75 to maintain separation (break < low invariant)
+- threshold-high unchanged at 80
+- Rationale: 1,422 tests + ~80% line coverage gives confidence mutation score > 65
+- **If the first Monday run fails**, dial back to 60 and investigate
+
+**#878 — Coverage floor:**
+- **No change needed.** Coverage floor already exists in `squad-ci.yml` at 80% line coverage (set per Anthony directive in a prior session)
+- Verified current coverage: 80.01% (7,386/9,231 lines)
+- 80% > requested 78% — existing gate satisfies the issue; documented in comment
+- Updated comment in squad-ci.yml to reference #878
+
+**Safety margins applied:**
+- Stryker: raised conservatively, flagged for first-run verification
+- Coverage: existing 80% gate retained (not lowered to 78%)

--- a/.ai-team/decisions/inbox/fitz-ci-improvements.md
+++ b/.ai-team/decisions/inbox/fitz-ci-improvements.md
@@ -1,0 +1,21 @@
+# Decision: CI Improvements #876 #877 #878
+
+**Date:** 2026-03-xx  
+**Author:** Fitz  
+**Branch:** squad/876-877-878-ci-improvements
+
+## Stryker Threshold (affects: Romanoff, team)
+
+Raised `--threshold-break` from 50 → 65 in `squad-stryker.yml`.  
+Also raised `--threshold-low` from 65 → 75 to maintain proper separation.  
+
+**Risk:** Cannot verify current mutation score without a live run (Stryker is schedule-only, ~30 min runtime). Confidence based on 1,422 tests + 80% line coverage.  
+**Action if first Monday run fails:** Dial threshold back to 60 and file an issue for Romanoff to improve mutation coverage.
+
+## Coverage Floor #878 (affects: whole team)
+
+Issue #878 asked for a 78% coverage floor. The floor was **already present at 80%** (Anthony directive from prior session). No threshold change was made — 80% > 78% so it already satisfies the ask. Documented in squad-ci.yml comment.
+
+## osx-x64 Release Artifact (affects: players, release process)
+
+Added osx-x64 as a third publish target in squad-release.yml. Tested by inspection only — cross-compilation of self-contained executables is supported by .NET 10. Note: `PublishReadyToRun` may produce a warning for osx-x64 on ubuntu-latest runner (cross-OS R2R is limited); build won't fail but binary may not have R2R optimization.

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -36,9 +36,10 @@ jobs:
         run: dotnet build --no-restore
 
       - name: Run tests with coverage
-        # TARGET GATE: 80% line coverage required (Anthony directive).
-        # Baseline at gate introduction: ~61.75% line coverage.
-        # PRs must reach 80% before this step will pass.
+        # COVERAGE FLOOR: 80% line coverage required (Anthony directive, #878 satisfied).
+        # Baseline at gate introduction: ~61.75%. Current at #878 audit: ~80.0%.
+        # Floor is set at 80% — stricter than the requested 78%, no change needed.
+        # If coverage drops below 80% this step will fail loudly.
         run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Threshold=80 /p:ThresholdType=line
 
       - name: Enforce PR closes-issue reference

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -75,11 +75,23 @@ jobs:
             /p:PublishReadyToRun=true \
             -o publish/win-x64
 
+      - name: Publish osx-x64
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          dotnet publish Dungnz.csproj \
+            -c Release \
+            -r osx-x64 \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:PublishReadyToRun=true \
+            -o publish/osx-x64
+
       - name: Archive artifacts
         if: steps.check_tag.outputs.exists == 'false'
         run: |
           cd publish/linux-x64 && zip -j ../../dungnz-linux-x64.zip * && cd ../..
           cd publish/win-x64 && zip -j ../../dungnz-win-x64.zip * && cd ../..
+          cd publish/osx-x64 && zip -j ../../dungnz-osx-x64.zip * && cd ../..
 
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false'
@@ -89,6 +101,7 @@ jobs:
           gh release create "${{ steps.version.outputs.tag }}" \
             dungnz-linux-x64.zip \
             dungnz-win-x64.zip \
+            dungnz-osx-x64.zip \
             --title "${{ steps.version.outputs.tag }}" \
             --generate-notes \
             --latest

--- a/.github/workflows/squad-stryker.yml
+++ b/.github/workflows/squad-stryker.yml
@@ -28,11 +28,14 @@ jobs:
 
       - name: Run Stryker mutation tests
         run: |
+          # threshold-break raised from 50 → 65 (#877). threshold-low raised to 75
+          # to maintain separation. Cannot verify live score without a full run;
+          # 80% line coverage + 1422 tests gives confidence this is safe.
           dotnet stryker \
             --project Dungnz.csproj \
             --test-project Dungnz.Tests/Dungnz.Tests.csproj \
-            --threshold-break 50 \
-            --threshold-low 65 \
+            --threshold-break 65 \
+            --threshold-low 75 \
             --threshold-high 80 \
             --reporter "html" \
             --reporter "progress" \


### PR DESCRIPTION
Closes #876
Closes #877
Closes #878

## Summary

**#876 — osx-x64 publish target**
Added `Publish osx-x64` step to `squad-release.yml`. Produces `dungnz-osx-x64.zip` attached to every GitHub Release alongside linux and win artifacts.

**#877 — Stryker mutation threshold raised**
Raised `--threshold-break` 50 → 65 in `squad-stryker.yml`. Also raised `--threshold-low` 65 → 75 to maintain proper band separation (break < low < high). Could not verify live score (Stryker is schedule-only; ~30 min runtime). Confidence based on 1,422 tests and 80% line coverage. If the first Monday run fails, dial back to 60.

**#878 — Coverage floor**
Already done — `squad-ci.yml` has `/p:Threshold=80 /p:ThresholdType=line` (Anthony directive). Verified current coverage: **80.01%** (7,386/9,231 lines). The existing 80% floor exceeds the requested 78%; no change to the gate value. Updated comment in squad-ci.yml to reference #878 and document the measurement.