### PR TITLE
fix: resolve LootTable static state contamination between tests

### DIFF
--- a/.ai-team/agents/barton/history.md
+++ b/.ai-team/agents/barton/history.md
@@ -1110,3 +1110,33 @@ Adding ASCII art for enemies is **highly feasible**. The project's existing data
 ---
 
 📌 **Team update (2026-03-01):** Retro action items adopted by team — stub-gap policy (new IDisplayService methods must have same-day stubs in FakeDisplayService and TestDisplayService before merge); sentinel pattern ban (use typed discriminated records or result enums; replace existing __TAKE_ALL__ sentinel, P1); cross-layer domain sync required (15-min upfront sync before work on features spanning display + game loop + systems); same-day push rule (completed work must be pushed with draft PR by end of session); pre-existing red tests are P0 (triage within same iteration); content review for player-facing strings. — decided by Coulson (Retrospective)
+
+### 2026-03-03 — Affix Audit: Wire 5 Unwired Properties (#871)
+
+**PR:** #894 — `fix: wire 5 unwired affix properties`
+**Branch:** `squad/871-wire-affix-properties`
+
+## Learnings
+
+**What the 5 affix properties were:**
+All 5 were defined in `Systems/AffixRegistry.cs` as `AffixDefinition` fields and in `Data/item-affixes.json`, but `ApplyAffixStats()` had TODO comments instead of actually writing them to `Item` fields — so no equipped item ever had non-zero values for these stats.
+
+**Which were wired vs removed:**
+All 5 were implemented (none removed) — the combat system already had the necessary hooks:
+
+| Property | Where wired | Mechanism |
+|---|---|---|
+| `EnemyDefReduction` | `Engine/CombatEngine.cs` | `Math.Max(0, enemy.Defense - player.EnemyDefReduction)` before damage calc |
+| `HolyDamageVsUndead` | `Engine/CombatEngine.cs` | Damage multiplier when `enemy.IsUndead` |
+| `BlockChanceBonus` | `Engine/CombatEngine.cs` | Roll after dodge check — fully negates incoming hit |
+| `ReviveCooldownBonus` | `Systems/PassiveEffectProcessor.cs` | `ApplyPhoenixRevive` now allows a 2nd per-run charge via `PhoenixExtraChargeUsed` flag |
+| `PeriodicDmgBonus` | `Engine/CombatEngine.cs` | Flat damage to enemy at `OnTurnStart` |
+
+**Key file paths touched:**
+- `Models/Item.cs` — added 5 new fields
+- `Models/PlayerCombat.cs` — 5 computed player properties (summed from equipment in `RecalculateDerivedBonuses`), `PhoenixExtraChargeUsed` flag
+- `Systems/AffixRegistry.cs` — removed TODO stubs, wrote to item fields
+- `Systems/PassiveEffectProcessor.cs` — `ApplyPhoenixRevive` extra charge logic
+- `Engine/CombatEngine.cs` — 4 combat-time wires
+
+**Design note:** `ReviveCooldownBonus` required a new `PhoenixExtraChargeUsed` run-level flag on Player (not per-combat — phoenix is once-per-run). The existing `PhoenixUsedThisRun` was extended rather than replaced.

--- a/.ai-team/agents/romanoff/history.md
+++ b/.ai-team/agents/romanoff/history.md
@@ -1044,3 +1044,39 @@ With `SelfHealCooldown=1` and check-first: fires on turn 2 (correct, matching as
 - Interactive menu tests inject input via FakeInputReader passed to FakeDisplayService constructor
 
 **Test Count:** Not yet run due to build errors (Hill needs to add XML doc comments). Tests are structurally complete and ready.
+
+---
+
+### 2026-03-03 — DisplayServiceSmokeTests for Markup Rendering (#875)
+
+**PR:** #895 — `test: add DisplayService smoke test suite`
+**Branch:** `squad/875-display-smoke-tests`
+**File Created:** `Dungnz.Tests/Display/DisplayServiceSmokeTests.cs`
+
+**Problem:**
+- ShowInventory, ShowEquipment, ShowSkillTree, ShowHelp, ShowCombatStatus had zero test coverage
+- Markup regressions (unescaped `[...]` in content passed to Spectre) only caught by manual play
+- Issue #870 (ShowHelp crash) proved the risk is real — needs automated guard for all 5 methods
+
+**Solution:**
+- 8 smoke tests using the AnsiConsole output-capture pattern from HelpDisplayRegressionTests
+- Swap `AnsiConsole.Console` with a non-interactive no-color writer backed by `StringWriter`; restore in `Dispose()`
+- Call the display method; if any unescaped bracket exists in markup, Spectre throws `MarkupException` — test catches it via `Should().NotThrow()`
+
+**Tests Written:**
+- `ShowInventory_WithItems_DoesNotThrow` — 3-item inventory (weapon, consumable, armor), full table render path
+- `ShowInventory_WhenEmpty_DoesNotThrow` — empty state branch, asserts "empty" in output
+- `ShowEquipment_WithGear_DoesNotThrow` — weapon + chest equipped; asserts item names in output
+- `ShowEquipment_AllSlotsEmpty_DoesNotThrow` — all null slots; exercises AddSlot null branch
+- `ShowSkillTreeMenu_NoLearnableSkills_DoesNotThrow` — Level 2 player (all skills require L3+); no interactive Prompt triggered
+- `ShowHelp_DoesNotThrow` — reinforces #870 regression guard
+- `ShowCombatStatus_NoEffects_DoesNotThrow` — bare HP table, no effects badges
+- `ShowCombatStatus_WithActiveEffects_DoesNotThrow` — Poison+Bleed on player, Burn on enemy; exercises effect-badge markup path
+
+**Key Learnings:**
+- **AnsiConsole capture pattern CONFIRMED:** Replace `AnsiConsole.Console` via `AnsiConsole.Create(new AnsiConsoleSettings { Ansi = AnsiSupport.No, ColorSystem = ColorSystemSupport.NoColors, Out = new AnsiConsoleOutput(writer), Interactive = InteractionSupport.No })`. Restore in Dispose. This is now the established standard.
+- **ShowSkillTreeMenu interactive prompt avoidance:** Level 2 player has no learnable skills (min is L3), so the method returns null without calling `AnsiConsole.Prompt()`. Any level 1-2 player is safe for smoke testing this method.
+- **`[Collection("console-output")]`** is mandatory — prevents parallel test races when multiple test classes redirect `AnsiConsole.Console`.
+- **Active effects markup:** The `[[effect name t]]` pattern in ShowCombatStatus uses `Markup.Escape()` on the effect name and double brackets for the outer wrapper — verified no regressions.
+
+**Test Count:** 1422 baseline → 1430 with new tests (8 added)

--- a/.ai-team/decisions/inbox/barton-affix-audit.md
+++ b/.ai-team/decisions/inbox/barton-affix-audit.md
@@ -1,0 +1,19 @@
+# Decision: All 5 Unwired Affix Properties Implemented (not removed)
+
+**Author:** Barton
+**Date:** 2026-03-03
+**Issue:** #871
+
+## Decision
+All 5 previously-dead affix properties (`EnemyDefReduction`, `HolyDamageVsUndead`, `BlockChanceBonus`, `ReviveCooldownBonus`, `PeriodicDmgBonus`) are now fully wired. None were removed from loot tables.
+
+## Rationale
+The combat system had sufficient hooks for all 5 to be implemented cleanly:
+- `EnemyDefReduction` and `HolyDamageVsUndead` fit naturally into the player damage calculation section
+- `BlockChanceBonus` slots cleanly next to the existing dodge check
+- `PeriodicDmgBonus` fits in `OnTurnStart` (same place as `belt_regen`)
+- `ReviveCooldownBonus` extended the existing `phoenix_revive` passive — required a new run-level flag `PhoenixExtraChargeUsed` on Player
+
+## Impact for other agents
+- **Romanoff (Tester):** New fields on `Item` and `Player` are testable. Key scenarios: (1) enemy DEF reduction clamped to 0 when reduction > enemy.Defense, (2) holy damage only fires when `enemy.IsUndead = true`, (3) block is independent of dodge (both can exist), (4) phoenix extra charge consumes `PhoenixExtraChargeUsed` not `PhoenixUsedThisRun`.
+- **Hill:** No Player model structural changes — only new auto-properties on `PlayerCombat.cs` partial class. `RecalculateDerivedBonuses()` now sums all 5 new item fields from equipped gear.

--- a/.ai-team/decisions/inbox/hill-discriminator-casing.md
+++ b/.ai-team/decisions/inbox/hill-discriminator-casing.md
@@ -1,0 +1,38 @@
+# Decision: JsonDerivedType Discriminator Casing Convention
+
+**Author:** Hill
+**Date:** 2026-03-03
+**Related Issue:** #873
+**Related PR:** #891
+
+## Decision
+
+All `[JsonDerivedType]` discriminator strings must use **all-lowercase** with no separators.
+
+**Rule:** Take the class name, lowercase every character, concatenate. No underscores, no hyphens, no PascalCase.
+
+Examples:
+- `DarkKnight` → `"darkknight"`
+- `GoblinShaman` → `"goblinshaman"`
+- `VampireLord` → `"vampirelord"`
+
+## Rationale
+
+`System.Text.Json` polymorphic deserialization is **case-sensitive** by default. Mixed casing (some PascalCase, some lowercase) causes silent deserialization failures — wrong-type or null results with no exception thrown. This creates hard-to-debug save corruption.
+
+All-lowercase is already used by the majority of our enemy discriminators (31 out of 41 before this fix). Standardizing eliminates the inconsistency.
+
+## Backward Compatibility Impact
+
+Save files written with the old PascalCase discriminators ("Goblin", "Skeleton", "Troll", "DarkKnight", "Mimic", "StoneGolem", "VampireLord", "Wraith", "DungeonBoss", "DungeonBoss") will **not** deserialize correctly after this change.
+
+**Decision:** No migration tooling. Saves are ephemeral in the current dev phase. If this becomes customer-facing before a migration is implemented, a JsonConverter shim with a case-insensitive fallback should be added.
+
+## Applies To
+
+- `Models/Enemy.cs` — `Enemy` base class `[JsonDerivedType]` attributes
+- Any future base class using `[JsonPolymorphic]` + `[JsonDerivedType]`
+
+## Action Required
+
+- Romanoff: Add a round-trip serialization test per acceptance criteria in #873 that verifies each enemy subtype serializes and deserializes correctly with the new discriminators.

--- a/.ai-team/decisions/inbox/romanoff-display-smoke-tests.md
+++ b/.ai-team/decisions/inbox/romanoff-display-smoke-tests.md
@@ -1,0 +1,54 @@
+# Decision: AnsiConsole Capture Pattern is Established Standard
+
+**Date:** 2026-03-03
+**Author:** Romanoff (Tester)
+**Issue:** #875 — DisplayService smoke tests
+
+## Decision
+
+The `AnsiConsole.Console` swap pattern used in `HelpDisplayRegressionTests` (#870) is now **confirmed and established** as the standard approach for all Spectre.Console display method tests in this project.
+
+## Pattern
+
+```csharp
+[Collection("console-output")]
+public sealed class MyTests : IDisposable
+{
+    private readonly IAnsiConsole _originalConsole;
+    private readonly StringWriter _writer;
+
+    public MyTests()
+    {
+        _originalConsole = AnsiConsole.Console;
+        _writer = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi        = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out         = new AnsiConsoleOutput(_writer),
+            Interactive = InteractionSupport.No,
+        });
+    }
+
+    public void Dispose()
+    {
+        AnsiConsole.Console = _originalConsole;
+        _writer.Dispose();
+    }
+}
+```
+
+## Rules
+
+1. **Always use `[Collection("console-output")]`** on any test class that redirects `AnsiConsole.Console`. Parallel execution without this causes races.
+2. **`MarkupException` is the primary failure mode** for unescaped brackets — `Should().NotThrow()` catches this automatically.
+3. **For `ShowSkillTreeMenu`:** use a level ≤ 2 player to avoid the interactive `AnsiConsole.Prompt()` call. All skills require level 3+.
+4. **For interactive prompts in other methods** (e.g., `ShowInventoryAndSelect`): do not test with `SpectreDisplayService` directly — use `FakeDisplayService` instead.
+
+## Coverage Added (#875)
+
+- `ShowInventory` (with items, empty)
+- `ShowEquipment` (with gear, all empty)
+- `ShowSkillTreeMenu` (no-learnable-skills path)
+- `ShowHelp`
+- `ShowCombatStatus` (no effects, active effects on both sides)

--- a/Dungnz.Tests/LootTableTests.cs
+++ b/Dungnz.Tests/LootTableTests.cs
@@ -126,9 +126,9 @@ public class LootTableTests
         }
         finally
         {
-            // Restore shared pools so this static mutation doesn't affect other tests
-            var placeholder = new List<Item> { new Item { Name = "Restore" } }.AsReadOnly();
-            LootTable.SetTierPools(placeholder, placeholder, placeholder);
+            // Reset to null so fallback lists are used — avoids contaminating other tests
+            // with single-tier placeholder items that skew distribution assertions.
+            LootTable.ResetTierPools();
         }
     }
 }

--- a/Models/LootTable.cs
+++ b/Models/LootTable.cs
@@ -60,6 +60,20 @@ public class LootTable
     }
 
     /// <summary>
+    /// Resets all shared tier pools to <see langword="null"/> so that subsequent
+    /// <see cref="RollTier"/> and <see cref="RollDrop"/> calls fall back to the
+    /// hardcoded fallback lists. Intended for test cleanup only.
+    /// </summary>
+    internal static void ResetTierPools()
+    {
+        _sharedTier1 = null;
+        _sharedTier2 = null;
+        _sharedTier3 = null;
+        _sharedLegendary = null;
+        _sharedEpic = null;
+    }
+
+    /// <summary>
     /// Picks a random item of the specified tier from the shared tier pools.
     /// Returns <see langword="null"/> if the tier pool is empty.
     /// </summary>


### PR DESCRIPTION
## Summary

The `EmptyTierPools` test in `LootTableTests` was restoring the `LootTable` shared tier pools with a single Common-tier placeholder item in its finally block. When `LootDistributionSimulationTests` ran after this, it inherited those contaminated pools and got 100% Common drops instead of the expected 60/30/10 distribution.

## Fix
- Added `LootTable.ResetTierPools()` (internal, test-only) that sets all static pools back to `null`
- Updated the finally block to call `ResetTierPools()` instead of overwriting with placeholder items

1430/1430 tests passing.