### PR TITLE
Log session: Close stale issues #870, #860

### DIFF
--- a/.ai-team/log/2026-03-03-close-stale-issues.md
+++ b/.ai-team/log/2026-03-03-close-stale-issues.md
@@ -1,0 +1,23 @@
+# Session: Close Stale Issues
+
+**Date:** 2026-03-03
+**Requested by:** Copilot (Anthony)
+
+## Summary
+Investigated 2 open GitHub issues (#870, #860) and found both already resolved in codebase — issues were not closed.
+
+## Work Completed
+
+### Issue #870: HelpDisplayRegressionTests.cs Missing
+- **Status:** CLOSED
+- **Finding:** HelpDisplayRegressionTests.cs exists and passes
+- **Resolution:** Issue resolved; test file is present and functional
+
+### Issue #860: Architecture Test - Models_Must_Not_Depend_On_Systems
+- **Status:** CLOSED
+- **Finding:** Architecture test Models_Must_Not_Depend_On_Systems passes
+- **Note:** Test validates namespace isolation, not folder structure
+- **Resolution:** Namespace check confirms proper architecture separation
+
+## Outcome
+Both issues have been addressed and closed. Codebase is in compliance with both issues.


### PR DESCRIPTION
Scribe session logging:
- HelpDisplayRegressionTests.cs verified present and passing
- Models_Must_Not_Depend_On_Systems arch test passes
- Both issues closed; codebase in compliance