### PR TITLE
chore: gitignore coverage output files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ obj/
 *.trx
 **/TestResults/
 coverage.opencover.xml
+coverage.cobertura.xml
+**/coverage/


### PR DESCRIPTION
## Problem
After local `dotnet test` runs with coverlet enabled, `Dungnz.Tests/coverage/coverage.cobertura.xml` appeared as an untracked file in `git status`, creating misleading "pending changes" on master.

## Root Cause
`.gitignore` only excluded `coverage.opencover.xml` — it did not cover the cobertura format output or the directory itself.

## Fix
Added two entries to `.gitignore`:
- `coverage.cobertura.xml` — cobertura XML files by name
- `**/coverage/` — the entire coverage output directory wherever it appears

## Prevention
These entries ensure local test coverage runs never pollute `git status` regardless of which coverage format is used or which subdirectory coverlet writes to.