### PR TITLE
fix: rename INVENTORY menu title to 'Inspect an item'

### DIFF
--- a/Display/SpectreDisplayService.cs
+++ b/Display/SpectreDisplayService.cs
@@ -308,7 +308,7 @@ public sealed class SpectreDisplayService : IDisplayService
         // Build selection list
         var items = player.Inventory.ToList();
         var prompt = new SelectionPrompt<string>()
-            .Title("[yellow]Select an item:[/]")
+            .Title("[yellow]Inspect an item:[/]")
             .PageSize(12)
             .MoreChoicesText("[grey](Move up and down to see more items)[/]")
             .AddChoices(items.Select(i => i.Name))


### PR DESCRIPTION
Closes #911

Changed the INVENTORY selection menu title from `Select an item:` to `Inspect an item:` in `Display/SpectreDisplayService.cs` (line 311).