### PR TITLE
fix: Remove dead 'E' (Equipped) column from INVENTORY view

### DIFF
--- a/Display/SpectreDisplayService.cs
+++ b/Display/SpectreDisplayService.cs
@@ -270,24 +270,19 @@ public sealed class SpectreDisplayService : IDisplayService
             .AddColumn(new TableColumn("[bold grey]#[/]").NoWrap())
             .AddColumn(new TableColumn("[bold grey]Name[/]"))
             .AddColumn(new TableColumn("[bold grey]Type[/]").NoWrap())
-            .AddColumn(new TableColumn("[bold grey]Tier[/]").NoWrap())
-            .AddColumn(new TableColumn("[bold grey]E[/]").NoWrap());
+            .AddColumn(new TableColumn("[bold grey]Tier[/]").NoWrap());
 
         int idx = 1;
         foreach (var group in player.Inventory.GroupBy(i => i.Name))
         {
             var item      = group.First();
             var count     = group.Count();
-            var isEquipped = item == player.EquippedWeapon
-                          || item == player.EquippedAccessory
-                          || player.AllEquippedArmor.Contains(item);
             var tc        = TierColor(item.Tier);
             var nameMk    = $"[{tc}]{Markup.Escape(item.Name)}[/]" + (count > 1 ? $" [grey]×{count}[/]" : "");
-            var equip     = isEquipped ? "[green]✓[/]" : "";
             var typeLabel = item.Type == ItemType.Armor && item.Slot != ArmorSlot.None
                 ? item.Slot.ToString()
                 : item.Type.ToString();
-            table.AddRow(idx.ToString(), nameMk, Markup.Escape(typeLabel), $"[{tc}]{item.Tier}[/]", equip);
+            table.AddRow(idx.ToString(), nameMk, Markup.Escape(typeLabel), $"[{tc}]{item.Tier}[/]");
             idx++;
         }
 


### PR DESCRIPTION
Closes #913

## Summary
Removes the always-empty `E` column from the inventory table.

## Root Cause
`EquipItem()` calls `Inventory.Remove(item)` when equipping, so equipped items never appear in `player.Inventory`. The `isEquipped` check iterated that list — it was structurally impossible for it to ever be `true`.

## Changes
- Removed `E` column header from `ShowInventory()`
- Removed `isEquipped` variable, `equip` variable, and the column slot from `AddRow`

## Tests
1430 tests passing.