### PR TITLE
fix: Pin CsCheck to 4.0.0 to resolve NU1603 build warning

### DIFF
--- a/Dungnz.Tests/Dungnz.Tests.csproj
+++ b/Dungnz.Tests/Dungnz.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CsCheck" Version="3.8.3" />
+    <PackageReference Include="CsCheck" Version="4.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
Resolves NU1603 build warning — CsCheck was referenced as >= 3.8.3 but only 4.0.0 is available. Pinned to 4.0.0.

All 1430 tests passing.