### PR TITLE
fix: add null-guards to GameLoop constructor and Run methods

### DIFF
--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -98,6 +98,8 @@ public class GameLoop
     /// </param>
     public GameLoop(IDisplayService display, ICombatEngine combat, IInputReader? input = null, GameEvents? events = null, int? seed = null, DifficultySettings? difficulty = null, IReadOnlyList<Item>? allItems = null, IMenuNavigator? navigator = null, ILogger<GameLoop>? logger = null)
     {
+        ArgumentNullException.ThrowIfNull(display);
+        ArgumentNullException.ThrowIfNull(combat);
         _display = display;
         _combat = combat;
         _input = input ?? new ConsoleInputReader();
@@ -170,6 +172,9 @@ public class GameLoop
     /// </summary>
     public void Run(GameState state)
     {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(state.Player);
+        ArgumentNullException.ThrowIfNull(state.CurrentRoom);
         _player = state.Player;
         _currentRoom = state.CurrentRoom;
         _currentFloor = state.CurrentFloor;
@@ -714,7 +719,7 @@ public class GameLoop
         ShowGameOver(killedBy: killedBy);
         RecordRunEnd(won: false);
         _gameOver = true;
-        if (_context != null!) _context.GameOver = true;
+        if (_context is not null) _context.GameOver = true;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #928

## What was wrong

## What was fixed
- Added `ArgumentNullException.ThrowIfNull(display)` and `ArgumentNullException.ThrowIfNull(combat)` at the top of the constructor — ensures GameLoop can never be constructed with null required services
- Added `ArgumentNullException.ThrowIfNull(state)`, `ArgumentNullException.ThrowIfNull(state.Player)`, and `ArgumentNullException.ThrowIfNull(state.CurrentRoom)` in `Run(GameState)` — catches corrupt/null save state at entry before any assignment
- Replaced `if (_context != null!)` with idiomatic `if (_context is not null)` to remove the confusing null-forgiving usage in a comparison context