### PR TITLE
fix: log exceptions in PrestigeSystem instead of swallowing silently

### DIFF
--- a/Systems/PrestigeSystem.cs
+++ b/Systems/PrestigeSystem.cs
@@ -63,12 +63,16 @@ public static class PrestigeSystem
             }
             return data;
         }
-        catch { return new PrestigeData(); }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceError($"[PrestigeSystem] Failed to load prestige data: {ex.Message}");
+            return new PrestigeData();
+        }
     }
 
     /// <summary>
     /// Persists the given <see cref="PrestigeData"/> to disk as JSON.
-    /// Silently swallows any I/O errors to avoid crashing the game on save failure.
+    /// I/O errors are traced via <see cref="System.Diagnostics.Trace"/> rather than crashing the game.
     /// </summary>
     /// <param name="data">The prestige data to save.</param>
     public static void Save(PrestigeData data)
@@ -78,7 +82,10 @@ public static class PrestigeSystem
             Directory.CreateDirectory(Path.GetDirectoryName(ActualSavePath)!);
             File.WriteAllText(ActualSavePath, JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
         }
-        catch { /* silently fail */ }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceError($"[PrestigeSystem] Failed to save prestige data: {ex.Message}");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #929

## What was wrong
`PrestigeSystem.Load()` and `PrestigeSystem.Save()` used bare `catch { }` blocks that swallowed all exceptions without any record. If the prestige file was corrupt, unreadable, or the disk was full, the player's prestige data would silently reset or fail to persist — with no trace, no log, no error message.

## What was fixed
- `Load()` catch now captures `Exception ex` and calls `Trace.TraceError()` with the context and message before returning defaults
- `Save()` catch now captures `Exception ex` and calls `Trace.TraceError()` with the context and message
- Both remain non-crashing (guard saves and loads must not bring down the game), but failures now emit a diagnostic trace observable via any attached trace listener or debug output
- Updated XML doc on `Save()` to remove the `'Silently swallows'` language