### PR TITLE
fix: replace Console.WriteLine with Trace.TraceWarning in PrestigeSystem

### DIFF
--- a/Systems/PrestigeSystem.cs
+++ b/Systems/PrestigeSystem.cs
@@ -58,7 +58,7 @@ public static class PrestigeSystem
             var data = JsonSerializer.Deserialize<PrestigeData>(json) ?? new PrestigeData();
             if (data.Version != 1)
             {
-                Console.WriteLine($"[PrestigeSystem] Warning: prestige file version {data.Version} is unexpected. Resetting to defaults.");
+                System.Diagnostics.Trace.TraceWarning($"[PrestigeSystem] prestige file version {data.Version} is unexpected. Resetting to defaults.");
                 return new PrestigeData();
             }
             return data;


### PR DESCRIPTION
Closes #930

## What was wrong
`PrestigeSystem.Load()` called `Console.WriteLine()` directly when detecting an unexpected prestige file version. This violates the display layer abstraction — all user-visible output should go through `IDisplayService`, and all diagnostic output in Systems/ should not hit stdout directly.

## What was fixed
Replaced the single `Console.WriteLine()` call with `System.Diagnostics.Trace.TraceWarning()`. Since `PrestigeSystem` is a static class with no dependency injection, `Trace` is the appropriate diagnostic channel — it routes to any configured `TraceListener` (including the debugger output window) without coupling to the display layer or crashing the game.

A full scan of `Engine/` and `Systems/` confirms this was the only offending `Console.Write*` call (excluding `IInputReader.cs` which wraps `Console.ReadLine/ReadKey` by design, and comments/XML docs).