### PR TITLE
fix: cap BlockChanceBonus at 95% to prevent invulnerability

### DIFF
--- a/Models/PlayerCombat.cs
+++ b/Models/PlayerCombat.cs
@@ -350,7 +350,7 @@ public partial class Player
 
         EnemyDefReduction = allEquipped.Sum(i => i.EnemyDefReduction);
         HolyDamageVsUndead = allEquipped.Sum(i => i.HolyDamageVsUndead);
-        BlockChanceBonus = allEquipped.Sum(i => i.BlockChanceBonus);
+        BlockChanceBonus = Math.Min(0.95f, allEquipped.Sum(i => i.BlockChanceBonus));
         HasReviveCooldownBonus = allEquipped.Any(i => i.ReviveCooldownBonus);
         PeriodicDmgBonus = allEquipped.Sum(i => i.PeriodicDmgBonus);
     }


### PR DESCRIPTION
Closes #917

## What was wrong
`BlockChanceBonus` in `PlayerCombat.RecalculateDerivedBonuses()` summed all equipped item bonuses with no upper bound. A player equipping multiple block-chance items could push the value above 1.0 (100%). Since the block check uses `_rng.NextDouble() < player.BlockChanceBonus`, and `NextDouble()` always returns [0.0, 1.0), values ≥ 1.0 guaranteed a block on every hit, making the player invulnerable to all physical attacks.

## What was fixed
Added `Math.Min(0.95f, ...)` cap in `RecalculateDerivedBonuses()` so block chance can never reach 100%. A 5% miss chance is always preserved, keeping counterplay intact for high-block builds.