### PR TITLE
fix: confirm and document Flurry/Assassinate cooldown assignment

### DIFF
--- a/Systems/AbilityManager.cs
+++ b/Systems/AbilityManager.cs
@@ -276,7 +276,10 @@ public class AbilityManager
             player.ArcaneSurgeReady = true;
             display.ShowCombatMessage("Next ability will cost 1 less mana. [Arcane Surge]"); // Fix #545: message fires on set-ready
         }
-        // Abilities with pre-conditions manage their own cooldown inside the case
+        // Abilities with pre-conditions manage their own cooldown inside the case block.
+        // Flurry and Assassinate require ComboPoints; RaiseDead/CorpseExplosion require minion state;
+        // LastStand requires low HP. All five call PutOnCooldown() only on the success path so that
+        // a failed pre-condition check (early return) does NOT put the ability on cooldown. (#920)
         if (type is not AbilityType.LastStand and not AbilityType.Flurry and not AbilityType.Assassinate
                   and not AbilityType.RaiseDead and not AbilityType.CorpseExplosion)
             PutOnCooldown(type, ability.CooldownTurns, player);


### PR DESCRIPTION
Closes #920

## Investigation
Both Flurry and Assassinate already call `PutOnCooldown(type, ability.CooldownTurns, player)` inside their case blocks on the success path (after the ComboPoints pre-condition check passes). The cooldowns are 3 turns for Flurry and 6 turns for Assassinate — neither can be spammed.

These abilities are intentionally excluded from the auto-cooldown gate at line 280 because the gate runs before the pre-condition check. If auto-cooldown ran unconditionally, a failed Flurry attempt (insufficient Combo Points) would incorrectly put the ability on cooldown even though it never fired.

## What was fixed
Expanded the comment on the exclusion condition to explicitly document the design rationale, preventing future regressions where someone might remove the manual `PutOnCooldown()` calls believing them to be redundant.