### PR TITLE
fix: reset Overcharge passive flag each turn to prevent permanent activation

### DIFF
--- a/Engine/CombatEngine.cs
+++ b/Engine/CombatEngine.cs
@@ -338,6 +338,9 @@ public class CombatEngine : ICombatEngine
             // ── Passive effects: turn start (belt_regen, warding_ring, etc.) ──
             _passives.ProcessPassiveEffects(player, PassiveEffectTrigger.OnTurnStart, enemy, 0);
 
+            // Reset per-turn Overcharge flag so the passive can trigger at most once per turn (#923)
+            player.OverchargeUsedThisTurn = false;
+
             // Periodic damage bonus from equipped affixes (e.g. "of Storms")
             if (player.PeriodicDmgBonus > 0 && enemy.HP > 0)
             {

--- a/Models/PlayerSkillHelpers.cs
+++ b/Models/PlayerSkillHelpers.cs
@@ -73,7 +73,7 @@ public partial class Player
     /// </summary>
     public bool IsOverchargeActive()
     {
-        return HasSkill(Skill.Overcharge) && Mana > MaxMana * 0.80f;
+        return HasSkill(Skill.Overcharge) && Mana > MaxMana * 0.80f && !OverchargeUsedThisTurn;
     }
 
     /// <summary>

--- a/Models/PlayerStats.cs
+++ b/Models/PlayerStats.cs
@@ -72,6 +72,13 @@ public partial class Player
     public bool IsManaShieldActive { get; set; } = false;
 
     /// <summary>
+    /// Tracks whether the Overcharge passive bonus (+25% spell damage) has already been consumed
+    /// this turn. Reset at the start of each player turn so Overcharge can only amplify the first
+    /// spell cast per turn, not every ability cast while mana stays above 80%.
+    /// </summary>
+    public bool OverchargeUsedThisTurn { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets whether the Evade ability is active (Rogue mechanic). Next enemy attack will miss.
     /// </summary>
     public bool EvadeNextAttack { get; set; } = false;

--- a/Systems/AbilityManager.cs
+++ b/Systems/AbilityManager.cs
@@ -382,7 +382,10 @@ public class AbilityManager
                 {
                     var baseDmg = (int)((player.Attack * 1.5) + (manaBeforeCast / 10));
                     if (player.IsOverchargeActive())
+                    {
                         baseDmg = (int)(baseDmg * 1.25);
+                        player.OverchargeUsedThisTurn = true;
+                    }
                     // Magic damage bypasses defense (or reduces it significantly)
                     var arcaneDamage = Math.Max(1, baseDmg - (enemy.Defense / 4));
                     enemy.HP -= arcaneDamage;
@@ -394,7 +397,10 @@ public class AbilityManager
                 {
                     var baseDmg = (int)(player.Attack * 1.2);
                     if (player.IsOverchargeActive())
+                    {
                         baseDmg = (int)(baseDmg * 1.25);
+                        player.OverchargeUsedThisTurn = true;
+                    }
                     var frostDamage = Math.Max(1, baseDmg - (enemy.Defense / 4));
                     enemy.HP -= frostDamage;
                     statusEffects.Apply(enemy, StatusEffect.Slow, 2);
@@ -431,7 +437,10 @@ public class AbilityManager
                 {
                     var baseDmg = (player.Attack * 3) + 20;
                     if (player.IsOverchargeActive())
+                    {
                         baseDmg = (int)(baseDmg * 1.25);
+                        player.OverchargeUsedThisTurn = true;
+                    }
                     var meteorDamage = Math.Max(1, baseDmg);
                     enemy.HP -= meteorDamage;
                     


### PR DESCRIPTION
Closes #923

## What was wrong
`IsOverchargeActive()` was a pure mana-level check with no usage tracking. A Mage above 80% mana received the Overcharge +25% spell damage bonus on *every* ability cast on *every* turn — a permanent buff with no counterplay as long as mana stayed high.

## What was fixed
- Added `OverchargeUsedThisTurn` flag to `PlayerStats`
- ArcaneBolt, FrostNova, and Meteor each set `player.OverchargeUsedThisTurn = true` after consuming the bonus
- `CombatEngine` resets the flag to `false` at the start of each player turn

**Result:** Overcharge now amplifies at most one spell per turn. A Mage can still leverage it every turn (by staying above 80% mana), but no longer gets the bonus on every cast within the same turn.