### PR TITLE
fix: cap EnemyDefReduction at 50 to prevent nullifying enemy defense

### DIFF
--- a/Dungnz.Tests/LootTableAdditionalTests.cs
+++ b/Dungnz.Tests/LootTableAdditionalTests.cs
@@ -168,7 +168,7 @@ public class LootTableAdditionalTests : IDisposable
 
         var table = new LootTable(new ControlledRandom(0.95), minGold: 10, maxGold: 10);
         // No explicit drops, boss room, so legendary should drop
-        var result = table.RollDrop(null!, playerLevel: 1, isBossRoom: true, dungeoonFloor: 1);
+        var result = table.RollDrop(null!, playerLevel: 1, isBossRoom: true, dungeonFloor: 1);
 
         result.Item.Should().NotBeNull("boss room guarantees legendary");
         result.Item!.Name.Should().Be("Boss Relic");
@@ -180,7 +180,7 @@ public class LootTableAdditionalTests : IDisposable
         LootTable.SetTierPools(new List<Item>(), new List<Item>(), new List<Item>(), legendary: new List<Item>());
 
         var table = new LootTable(new ControlledRandom(0.95), minGold: 5, maxGold: 5);
-        var result = table.RollDrop(null!, isBossRoom: true, dungeoonFloor: 1);
+        var result = table.RollDrop(null!, isBossRoom: true, dungeonFloor: 1);
 
         // No drop forced since legendary pool is empty; 95% rng prevents 30% tiered roll
         result.Gold.Should().Be(5);
@@ -236,7 +236,7 @@ public class LootTableAdditionalTests : IDisposable
         for (int seed = 0; seed < 100; seed++)
         {
             var table = new LootTable(new Random(seed), minGold: 0, maxGold: 0);
-            var result = table.RollDrop(null!, dungeoonFloor: 6);
+            var result = table.RollDrop(null!, dungeonFloor: 6);
             if (result.Item?.Name == "Legendary Artifact") { legendaryDropped = true; break; }
         }
         legendaryDropped.Should().BeTrue("floor 6+ has 5% legendary chance; should trigger in 100 attempts");
@@ -259,7 +259,7 @@ public class LootTableAdditionalTests : IDisposable
         for (int seed = 0; seed < 200; seed++)
         {
             var table = new LootTable(new Random(seed), minGold: 0, maxGold: 0);
-            var result = table.RollDrop(null!, dungeoonFloor: 5);
+            var result = table.RollDrop(null!, dungeonFloor: 5);
             if (result.Item?.Name == "Epic Armor") { epicDropped = true; break; }
         }
         epicDropped.Should().BeTrue("floor 5+ has 8% epic chance; should trigger within 200 attempts");
@@ -275,7 +275,7 @@ public class LootTableAdditionalTests : IDisposable
         for (int seed = 0; seed < 200; seed++)
         {
             var table = new LootTable(new Random(seed), minGold: 0, maxGold: 0);
-            var result = table.RollDrop(null!, dungeoonFloor: 7);
+            var result = table.RollDrop(null!, dungeonFloor: 7);
             if (result.Item?.Name == "High Epic") { epicDropped = true; break; }
         }
         epicDropped.Should().BeTrue("floor 7+ has 15% epic chance; should trigger within 200 attempts");

--- a/Models/LootTable.cs
+++ b/Models/LootTable.cs
@@ -160,10 +160,10 @@ public class LootTable
     /// <param name="enemy">The defeated enemy, used to check <see cref="Enemy.IsElite"/> for tier escalation.</param>
     /// <param name="playerLevel">The player's current level, used to select the appropriate item tier pool.</param>
     /// <param name="isBossRoom">When <see langword="true"/>, guarantees a Legendary drop from the boss pool.</param>
-    /// <param name="dungeoonFloor">Current dungeon floor (1-8); floors 6-8 have a 5% Legendary chance.</param>
+    /// <param name="dungeonFloor">Current dungeon floor (1-8); floors 6-8 have a 5% Legendary chance.</param>
     /// <param name="lootDropMultiplier">Multiplier applied to drop chances (from DifficultySettings).</param>
     /// <returns>A <see cref="LootResult"/> containing the optional item drop and the gold amount.</returns>
-    public LootResult RollDrop(Enemy enemy, int playerLevel = 1, bool isBossRoom = false, int dungeoonFloor = 1, float lootDropMultiplier = 1.0f)
+    public LootResult RollDrop(Enemy enemy, int playerLevel = 1, bool isBossRoom = false, int dungeonFloor = 1, float lootDropMultiplier = 1.0f)
     {
         int gold = _minGold == _maxGold ? _minGold : _rng.Next(_minGold, _maxGold + 1);
 
@@ -184,15 +184,15 @@ public class LootTable
 
         // Floors 5-8: Epic drop chance (8% on floors 5-6, 15% on floors 7-8)
         var epicPool = _sharedEpic ?? FallbackEpic;
-        if (dropped == null && dungeoonFloor >= 5 && epicPool.Count > 0)
+        if (dropped == null && dungeonFloor >= 5 && epicPool.Count > 0)
         {
-            double epicChance = dungeoonFloor >= 7 ? 0.15 : 0.08;
+            double epicChance = dungeonFloor >= 7 ? 0.15 : 0.08;
             if (_rng.NextDouble() < epicChance)
                 dropped = epicPool[_rng.Next(epicPool.Count)].Clone();
         }
 
         // Floors 6-8: 5% Legendary chance
-        if (dropped == null && dungeoonFloor >= 6 && legendaryPool.Count > 0 && _rng.NextDouble() < 0.05)
+        if (dropped == null && dungeonFloor >= 6 && legendaryPool.Count > 0 && _rng.NextDouble() < 0.05)
         {
             dropped = legendaryPool[_rng.Next(legendaryPool.Count)].Clone();
         }

--- a/Models/PlayerCombat.cs
+++ b/Models/PlayerCombat.cs
@@ -348,7 +348,7 @@ public partial class Player
             .Where(i => i != null)
             .Select(i => i!);
 
-        EnemyDefReduction = allEquipped.Sum(i => i.EnemyDefReduction);
+        EnemyDefReduction = Math.Min(50, allEquipped.Sum(i => i.EnemyDefReduction));
         HolyDamageVsUndead = Math.Min(1.0f, allEquipped.Sum(i => i.HolyDamageVsUndead));
         BlockChanceBonus = Math.Min(0.95f, allEquipped.Sum(i => i.BlockChanceBonus));
         HasReviveCooldownBonus = allEquipped.Any(i => i.ReviveCooldownBonus);


### PR DESCRIPTION
Closes #921

`EnemyDefReduction` was an unbounded sum of all equipped items, allowing stacked items to reduce enemy defense to zero and trivialize armored enemies. Capped at 50 matching the issue specification.

Also includes LootTable typo fix (#964): `dungeoonFloor` → `dungeonFloor` parameter rename.