### PR TITLE
fix: resolve XML doc comment build warnings

### DIFF
--- a/Display/DisplayService.cs
+++ b/Display/DisplayService.cs
@@ -837,6 +837,7 @@ public class ConsoleDisplayService : IDisplayService
     /// <param name="currentRoom">
     /// The room the player currently occupies, placed at origin (0,0) on the map.
     /// </param>
+    /// <param name="floor">The current dungeon floor number, displayed in the map header.</param>
     public void ShowMap(Room currentRoom, int floor = 1)
     {
         // BFS to assign (x, y) coordinates to every reachable room

--- a/Display/IDisplayService.cs
+++ b/Display/IDisplayService.cs
@@ -381,7 +381,7 @@ public interface IDisplayService
     /// Presents an arrow-key navigable skill tree menu showing all skills available to the player's class.
     /// Locked skills (level requirement not met) are displayed but cannot be selected.
     /// Already-unlocked skills are excluded entirely.
-    /// Returns the <see cref="Systems.Skill"/> the player wants to learn, or <c>null</c> if cancelled.
+    /// Returns the <see cref="Skill"/> the player wants to learn, or <c>null</c> if cancelled.
     /// </summary>
     /// <param name="player">The player viewing the skill tree.</param>
     Skill? ShowSkillTreeMenu(Player player);

--- a/Engine/CommandParser.cs
+++ b/Engine/CommandParser.cs
@@ -173,7 +173,7 @@ public static class CommandParser
 
     /// <summary>
     /// Attempts fuzzy matching when a command is not recognized.
-    /// If exactly one known verb has Levenshtein distance <= 1, returns that command.
+    /// If exactly one known verb has Levenshtein distance &lt;= 1, returns that command.
     /// Otherwise, returns Unknown command.
     /// </summary>
     private static ParsedCommand TryFuzzyMatch(string command, string argument)

--- a/Engine/Commands/CommandContext.cs
+++ b/Engine/Commands/CommandContext.cs
@@ -59,7 +59,7 @@ public class CommandContext
     public required Action<string> ExitRun { get; set; }
     /// <summary>Delegate that records the run outcome to history and evaluates achievements.</summary>
     public required Action<bool, string?> RecordRunEnd { get; set; }
-    /// <summary>Returns the item currently equipped in the slot that <paramref name="item"/> would occupy.</summary>
+    /// <summary>Returns the item currently equipped in the slot that the candidate item would occupy.</summary>
     public required Func<Player, Item?, Item?> GetCurrentlyEquippedForItem { get; set; }
     /// <summary>Returns a display-friendly label for the current difficulty setting.</summary>
     public required Func<string> GetDifficultyName { get; set; }

--- a/Engine/GoblinShamanAI.cs
+++ b/Engine/GoblinShamanAI.cs
@@ -17,7 +17,6 @@ public class GoblinShamanAI : IEnemyAI
     /// <summary>
     /// Executes Goblin Shaman turn: if HP below 50% and heal is off cooldown,
     /// self-heals for 20% MaxHP. Otherwise, defers to default attack.
-    /// Sets <see cref="TurnResult"/> to indicate what happened.
     /// </summary>
     public void TakeTurn(Enemy self, Player player, CombatContext context)
     {


### PR DESCRIPTION
Fixes 6 XML doc comment warnings (CS1570, CS1573, CS1574, CS1734) across 5 files:\n\n- `CommandParser.cs`: escape `<=` as `&lt;=` in XML comment\n- `DisplayService.cs`: add missing `<param name="floor">` to `ShowMap`\n- `IDisplayService.cs`: fix cref from `Systems.Skill` to `Skill`\n- `CommandContext.cs`: remove invalid `paramref` for non-existent param\n- `GoblinShamanAI.cs`: remove dangling cref to non-existent `TurnResult` type\n\nBuild now produces 0 warnings.