### PR TITLE
docs(ai-team): P0 bug hunt session log

### DIFF
--- a/.ai-team/log/2026-03-03-bug-hunt-p0-fixes.md
+++ b/.ai-team/log/2026-03-03-bug-hunt-p0-fixes.md
@@ -1,0 +1,40 @@
+# Session: 2026-03-03 Bug Hunt P0 Fixes
+
+**Requested by:** Anthony
+
+## Work Summary
+
+### P0 Combat Bugs (Barton)
+Fixed remaining critical combat bugs:
+- #918: HP bypass vulnerability
+- #922: HolyDamageVsUndead damage cap issue
+- #919: DodgeBonus damage cap
+- #921: EnemyDefReduction cap vulnerability
+- #924: LastStand boundary condition
+- #925: RecklessBlow clamp overflow
+- #926: Flee state deduplication
+- #927: PeriodicDmgBonus cooldown tracking
+
+### P1 Structural Issues (Hill)
+Fixed significant logic and data issues:
+- #939: AddXP overflow detection
+- #941: Empty room description pool fallback
+- #964: LootTable configuration typo
+- Confirmed #932 and #937 already resolved
+
+### Build Quality
+- Fixed 4 build warnings across 5 files (CS1570, CS1573, CS1574, CS1734)
+- Resolved XML documentation and serialization warnings
+
+### Merge Activity
+- 11 PRs merged (#972–#983)
+- Total tests: 1430/1430 passing
+- Build warnings: 0
+
+## Key Decisions & Notes
+- Two agents ran concurrently in the same git repository, causing commit entanglement
+- Resolved by pushing fixes directly to master and rebasing one conflicting branch
+- Final repository state: clean, fully tested, no warnings
+
+## Outcome
+Master branch stabilized with all P0 and P1 issues resolved.


### PR DESCRIPTION
Session: 2026-03-03-bug-hunt-p0-fixes

Requested by: Anthony

## Summary
Logged P0 bug hunt sprint with work from Barton (8 combat fixes) and Hill (4 structural fixes). Build warnings eliminated, 1430/1430 tests passing.

- Barton: HP bypass, damage caps, DodgeBonus, EnemyDefReduction, LastStand, RecklessBlow, flee dedup, PeriodicDmgBonus cooldown
- Hill: AddXP overflow, room description pool, LootTable typo, verified #932 and #937 fixed

11 PRs merged (#972–#983).