### PR TITLE
fix: P2 balance — FlameBreath ATK reduced, EnemyFactory init guards

### DIFF
--- a/Engine/CombatEngine.cs
+++ b/Engine/CombatEngine.cs
@@ -1427,10 +1427,10 @@ public class CombatEngine : ICombatEngine
                 break;
 
             case "FlameBreath":
-                // InfernalDragon: apply Burn 5 turns + permanently gain +8 ATK
+                // InfernalDragon: apply Burn 5 turns + gain +4 ATK for rest of combat
                 _statusEffects.Apply(player, StatusEffect.Burn, 5);
-                boss.Attack += 8;
-                _display.ShowCombatMessage($"You are set ablaze! (Burn 5T) The {boss.Name} grows fiercer (+8 ATK)!");
+                boss.Attack += 4;
+                _display.ShowCombatMessage($"You are set ablaze! (Burn 5T) The {boss.Name} grows fiercer (+4 ATK)!");
                 break;
         }
     }

--- a/Engine/EnemyFactory.cs
+++ b/Engine/EnemyFactory.cs
@@ -63,6 +63,7 @@ public static class EnemyFactory
     /// </returns>
     public static Enemy CreateRandom(Random rng)
     {
+        if (_enemyConfig == null) throw new InvalidOperationException("EnemyFactory.Initialize() must be called before creating enemies.");
         var type = rng.Next(9);
         var enemy = type switch
         {
@@ -99,6 +100,7 @@ public static class EnemyFactory
     /// <returns>A <see cref="DungeonBoss"/> instance ready for a boss-room encounter.</returns>
     public static Enemy CreateBoss(Random rng, int floor = 1)
     {
+        if (_enemyConfig == null) throw new InvalidOperationException("EnemyFactory.Initialize() must be called before creating enemies.");
         return floor switch
         {
             1 => new GoblinWarchief(_enemyConfig?.GetValueOrDefault("GoblinWarchief"), _itemConfig),


### PR DESCRIPTION
## Summary
Two P2 fixes from the deep-dive audit.

### Balance
- **#996** — InfernalDragon FlameBreath ATK bonus reduced from +8 to +4. Combined with Enrage (1.5x at 40% HP), the old +8 yielded 93 ATK from base 54 (72% increase). New +4 yields 87 ATK (61% increase) — still threatening but not one-shot territory.

### Tech Debt
- **#1000** — EnemyFactory.CreateRandom and CreateBoss now throw InvalidOperationException if Initialize() hasn't been called, matching the existing guard in CreateScaled.

### Test Results
- 0 warnings, 0 errors
- 1430/1430 tests passing

Closes #996 #1000