### PR TITLE
fix: populate Player Stats pane on game startup

### DIFF
--- a/Engine/GameLoop.cs
+++ b/Engine/GameLoop.cs
@@ -163,6 +163,7 @@ public class GameLoop
                          : Difficulty.Normal;
         _display.ShowMessage($"Difficulty: {GetDifficultyName()}");
         _display.ShowMessage($"Floor {_currentFloor}");
+        _display.ShowPlayerStats(player);
         _display.ShowRoom(_currentRoom);
         _currentRoom.Visited = true;
 
@@ -190,6 +191,7 @@ public class GameLoop
         _rng = _seed.HasValue ? new Random(_seed.Value) : new Random();
 
         _display.ShowMessage($"Loaded save — Floor {_currentFloor}");
+        _display.ShowPlayerStats(_player);
         _display.ShowRoom(_currentRoom);
         _currentRoom.Visited = true;
 


### PR DESCRIPTION
## Problem
Player Stats pane was blank until the user typed `STATS` explicitly.

## Root Cause
Hill's fix in PR #1045 added caching to `TerminalGuiDisplayService` so `ShowRoom()` would auto-refresh stats if `_player != null`. But `_player` was only ever set by `ShowPlayerStats()` — which was only called by `StatsCommandHandler`. On startup, `GameLoop.Run()` called `ShowRoom()` first, so `_player` was null and the stats panel was skipped.

## Fix
Added `_display.ShowPlayerStats(player)` calls in both `GameLoop.Run()` overloads immediately before `ShowRoom()`. This seeds the cache so the stats panel is populated from the very first room render.

## Testing
- All 1,988 existing tests pass
- No new tests needed (the existing `TuiPr1036NewFeatureTests` cover the `ShowRoom` auto-populate logic)