### PR TITLE
feat: context-based TUI content panel colors and HP/MP status labels

### DIFF
--- a/Display/Tui/TerminalGuiDisplayService.cs
+++ b/Display/Tui/TerminalGuiDisplayService.cs
@@ -120,6 +120,7 @@ public sealed class TerminalGuiDisplayService : IDisplayService
             if (room.Merchant != null)
                 sb.AppendLine("🛒 A merchant awaits. (SHOP)");
 
+            _layout.SetContentContext("room");
             _layout.SetContent(sb.ToString());
 
             // Auto-populate map and stats panels on room entry (#1038/#1039)
@@ -266,6 +267,7 @@ public sealed class TerminalGuiDisplayService : IDisplayService
                 if (delta > 0) sb.AppendLine($"(+{delta} vs equipped!)");
             }
 
+            _layout.SetContentContext("loot");
             _layout.AppendContent(sb.ToString() + "\n");
             _layout.AppendLog($"Loot: {item.Name}", "loot");
         });
@@ -277,6 +279,7 @@ public sealed class TerminalGuiDisplayService : IDisplayService
         GameThreadBridge.InvokeOnUiThread(() =>
         {
             var message = $"💰 +{amount} gold  (Total: {newTotal}g)";
+            _layout.SetContentContext("loot");
             _layout.AppendContent($"  {message}\n");
             _layout.AppendLog(message, "loot");
         });
@@ -288,6 +291,7 @@ public sealed class TerminalGuiDisplayService : IDisplayService
         GameThreadBridge.InvokeOnUiThread(() =>
         {
             var message = $"{GetItemIcon(item)} Picked up: {item.Name}  ({GetPrimaryStatLabel(item)})";
+            _layout.SetContentContext("loot");
             _layout.AppendContent($"  {message}\n");
             _layout.AppendContent($"  Slots: {slotsCurrent}/{slotsMax}  ·  Weight: {weightCurrent}/{weightMax}\n");
             _layout.AppendLog(message, "loot");
@@ -582,6 +586,7 @@ public sealed class TerminalGuiDisplayService : IDisplayService
             sb.AppendLine($"Off-Hand:  {(player.EquippedOffHand   != null ? $"{player.EquippedOffHand.Name,-20} ({GetPrimaryStatLabel(player.EquippedOffHand)})"   : "(none)")}");
             sb.AppendLine($"Accessory: {(player.EquippedAccessory != null ? $"{player.EquippedAccessory.Name,-20} ({GetPrimaryStatLabel(player.EquippedAccessory)})" : "(none)")}");
 
+            _layout.SetContentContext("gear");
             _layout.SetContent(sb.ToString());
         });
     }
@@ -710,6 +715,7 @@ public sealed class TerminalGuiDisplayService : IDisplayService
                 idx++;
             }
 
+            _layout.SetContentContext("shop");
             _layout.SetContent(sb.ToString());
         });
     }
@@ -797,6 +803,7 @@ public sealed class TerminalGuiDisplayService : IDisplayService
         GameThreadBridge.InvokeOnUiThread(() =>
         {
             _layout.SetContent($"\n═══ COMBAT: {enemy.Name} ═══\n\n");
+            _layout.SetContentContext("combat");
             _layout.AppendLog($"Combat started: {enemy.Name}");
         });
     }
@@ -1312,13 +1319,17 @@ public sealed class TerminalGuiDisplayService : IDisplayService
         sb.AppendLine();
 
         var hpBar = BuildColoredHpBar(player.HP, player.MaxHP);
-        sb.AppendLine($"HP: {hpBar}");
+        var hpPct = player.MaxHP > 0 ? (double)player.HP / player.MaxHP : 1.0;
+        var hpStatus = hpPct > 0.50 ? "OK" : hpPct >= 0.25 ? "LOW" : "CRIT";
+        sb.AppendLine($"HP: {hpBar} [{hpStatus}]");
         sb.AppendLine($"    {player.HP}/{player.MaxHP}");
 
         if (player.MaxMana > 0)
         {
             var mpBar = BuildColoredMpBar(player.Mana, player.MaxMana);
-            sb.AppendLine($"MP: {mpBar}");
+            var mpPct = player.MaxMana > 0 ? (double)player.Mana / player.MaxMana : 1.0;
+            var mpStatus = mpPct > 0.50 ? "OK" : mpPct >= 0.20 ? "LOW" : "EMPTY";
+            sb.AppendLine($"MP: {mpBar} [{mpStatus}]");
             sb.AppendLine($"    {player.Mana}/{player.MaxMana}");
         }
 

--- a/Display/Tui/TuiLayout.cs
+++ b/Display/Tui/TuiLayout.cs
@@ -17,6 +17,14 @@ public sealed class TuiLayout
     private readonly TextView _mapView;
     private readonly TextView _statsView;
 
+    // Content panel frame and context color schemes (#1059)
+    private readonly FrameView _contentFrame;
+    private readonly ColorScheme _normalScheme;
+    private readonly ColorScheme _combatScheme;
+    private readonly ColorScheme _shopScheme;
+    private readonly ColorScheme _lootScheme;
+    private readonly ColorScheme _gearScheme;
+
     /// <summary>Gets the main application window that hosts all panels.</summary>
     public Toplevel MainWindow { get; }
 
@@ -43,7 +51,7 @@ public sealed class TuiLayout
     public TuiLayout()
     {
         // High-contrast color schemes (#1036) — null-safe for test environments
-        var normalScheme = new ColorScheme
+        _normalScheme = new ColorScheme
         {
             Normal   = MakeAttr(Color.White, Color.Blue),
             Focus    = MakeAttr(Color.White, Color.Blue),
@@ -51,6 +59,45 @@ public sealed class TuiLayout
             HotFocus  = MakeAttr(Color.BrightYellow, Color.Blue),
             Disabled  = MakeAttr(Color.Gray, Color.Blue)
         };
+
+        // Context-sensitive content panel schemes (#1059)
+        _combatScheme = new ColorScheme
+        {
+            Normal    = MakeAttr(Color.BrightRed,    Color.Black),
+            Focus     = MakeAttr(Color.BrightRed,    Color.Black),
+            HotNormal = MakeAttr(Color.BrightYellow, Color.Black),
+            HotFocus  = MakeAttr(Color.BrightYellow, Color.Black),
+            Disabled  = MakeAttr(Color.Gray,         Color.Black)
+        };
+
+        _shopScheme = new ColorScheme
+        {
+            Normal    = MakeAttr(Color.BrightYellow, Color.Black),
+            Focus     = MakeAttr(Color.BrightYellow, Color.Black),
+            HotNormal = MakeAttr(Color.White,        Color.Black),
+            HotFocus  = MakeAttr(Color.White,        Color.Black),
+            Disabled  = MakeAttr(Color.Gray,         Color.Black)
+        };
+
+        _lootScheme = new ColorScheme
+        {
+            Normal    = MakeAttr(Color.BrightGreen,  Color.Black),
+            Focus     = MakeAttr(Color.BrightGreen,  Color.Black),
+            HotNormal = MakeAttr(Color.BrightYellow, Color.Black),
+            HotFocus  = MakeAttr(Color.BrightYellow, Color.Black),
+            Disabled  = MakeAttr(Color.Gray,         Color.Black)
+        };
+
+        _gearScheme = new ColorScheme
+        {
+            Normal    = MakeAttr(Color.BrightCyan,   Color.Black),
+            Focus     = MakeAttr(Color.BrightCyan,   Color.Black),
+            HotNormal = MakeAttr(Color.BrightYellow, Color.Black),
+            HotFocus  = MakeAttr(Color.BrightYellow, Color.Black),
+            Disabled  = MakeAttr(Color.Gray,         Color.Black)
+        };
+
+        var normalScheme = _normalScheme;
 
         var mapScheme = new ColorScheme
         {
@@ -134,7 +181,7 @@ public sealed class TuiLayout
         StatsPanel.Add(_statsView);
 
         // Middle: Content area (50% height)
-        var contentFrame = new FrameView("📜 Adventure")
+        _contentFrame = new FrameView("📜 Adventure")
         {
             X = 0,
             Y = Pos.Bottom(MapPanel),
@@ -153,13 +200,13 @@ public sealed class TuiLayout
             WordWrap = true,
             ColorScheme = normalScheme
         };
-        contentFrame.Add(ContentPanel);
+        _contentFrame.Add(ContentPanel);
 
         // Message log (15% height)
         var logFrame = new FrameView("📋 Message Log")
         {
             X = 0,
-            Y = Pos.Bottom(contentFrame),
+            Y = Pos.Bottom(_contentFrame),
             Width = Dim.Fill(),
             Height = Dim.Percent(15),
             ColorScheme = logScheme
@@ -198,7 +245,7 @@ public sealed class TuiLayout
         inputFrame.Add(CommandInput);
 
         // Add all panels to main window
-        MainWindow.Add(MapPanel, StatsPanel, contentFrame, logFrame, inputFrame);
+        MainWindow.Add(MapPanel, StatsPanel, _contentFrame, logFrame, inputFrame);
     }
 
     /// <summary>
@@ -283,6 +330,26 @@ public sealed class TuiLayout
     public void SetStats(string statsText)
     {
         _statsView.Text = statsText;
+        if (Application.Driver is not null)
+            Application.Refresh();
+    }
+
+    /// <summary>
+    /// Switches the content panel color scheme based on the current game context (#1059).
+    /// </summary>
+    /// <param name="context">One of: "combat", "shop", "loot", "gear", or any other value for normal.</param>
+    public void SetContentContext(string context)
+    {
+        var scheme = context switch
+        {
+            "combat" => _combatScheme,
+            "shop"   => _shopScheme,
+            "loot"   => _lootScheme,
+            "gear"   => _gearScheme,
+            _        => _normalScheme
+        };
+        _contentFrame.ColorScheme = scheme;
+        ContentPanel.ColorScheme  = scheme;
         if (Application.Driver is not null)
             Application.Refresh();
     }


### PR DESCRIPTION
Resolves #1058 and #1059 — makes TUI text color meaningfully variable based on game state.

## Changes

### TuiLayout.cs
- Added 4 new ColorScheme fields: combatScheme (BrightRed/Black), shopScheme (BrightYellow/Black), lootScheme (BrightGreen/Black), gearScheme (BrightCyan/Black)
- Promoted normalScheme and contentFrame to private fields
- Added SetContentContext(string context) — switches both frame border and panel text color at runtime

### TerminalGuiDisplayService.cs
- ShowRoom() → SetContentContext(room) White/Blue — default calm
- ShowCombatStart() → SetContentContext(combat) BrightRed/Black — urgent
- ShowEquipment() → SetContentContext(gear) BrightCyan/Black — info
- ShowShop() → SetContentContext(shop) BrightYellow/Black — commerce
- ShowLootDrop/ShowGoldPickup/ShowItemPickup → SetContentContext(loot) BrightGreen/Black — reward
- BuildStatsText: HP bar now shows [OK]/[LOW]/[CRIT]; MP bar shows [OK]/[LOW]/[EMPTY]

## Test Results
1,988 tests passing, 0 failures