### PR TITLE
fix(tui): border alignment and layout compactness

### DIFF
--- a/.ai-team/agents/coulson/history.md
+++ b/.ai-team/agents/coulson/history.md
@@ -3205,3 +3205,34 @@ This keeps the persistent split-screen layout we already built.
 
 **Recommendation:** Add RefreshDisplay(Player, Room, int floor) method that unconditionally updates all three panels. Call at turn boundaries and after combat/level-up/stat changes.
 
+
+
+### 2026-03-06: TUI Border Alignment and Layout Compactness Analysis
+
+**Context:** Anthony reported two visual quality issues with the Spectre.Console TUI: border misalignment on Floor/Stats panels, and excessive vertical space usage.
+
+**Border Alignment Root Cause:**
+- Emojis (🗺, ⚔) in panel headers are 1 character in Spectre markup but render as 2-cell width in terminals
+- Spectre.Console's `Panel.Header()` centers text by string length calculation, not display width
+- This causes 1-2 character misalignment between header text and border frame
+- Affects 4 locations: `SpectreLayoutDisplayService.cs` lines 130, 139 and `SpectreLayout.cs` lines 59, 66
+- **Fix:** Remove emojis from headers (e.g., `Floor N`, `Player Stats`) or add compensating spaces
+
+**Vertical Space Root Cause:**
+- Layout ratios: TopRow=30% (ratio 3), Content=50% (ratio 5), BottomRow=20% (ratio 2)
+- At 50 rows: Top=15, Content=25, Bottom=10
+- Content panel gets half the screen for scrolling narrative text — excessive for typical content density
+- Map/Stats cramped at 15 rows, Log history limited to 10 rows
+- **Fix:** Reduce Content ratio from 5 to 4 (50%→40%), increase BottomRow from 2 to 3 (20%→30%)
+
+**GitHub Issues Created:**
+- #1091: TUI border alignment issues with emoji headers
+- #1092: TUI layout ratios cause excessive vertical space usage
+
+Both issues tagged with `bug` label only (no `tui` label exists in repository).
+
+**Recommended Fixes:**
+- Issue #1091: Remove emojis from panel headers for cross-terminal compatibility
+- Issue #1092: Rebalance ratios to Content=40%, BottomRow=30% to give more log history visibility
+
+**Decision Document:** `.ai-team/decisions/inbox/coulson-tui-layout-compact-borders.md`

--- a/.ai-team/decisions/inbox/coulson-tui-layout-compact-borders.md
+++ b/.ai-team/decisions/inbox/coulson-tui-layout-compact-borders.md
@@ -1,0 +1,19 @@
+### 2026-03-06: TUI layout compactness and border alignment fixes
+
+**By:** Coulson
+
+**What:** Created two GitHub issues (#1091, #1092) documenting TUI display bugs:
+1. Border alignment issues caused by emoji width miscalculation in panel headers
+2. Excessive vertical space usage due to Content panel taking 50% of screen height
+
+**Why:** Anthony reported visual quality issues with the Spectre.Console TUI that impact player experience. The border misalignment creates a "janky" appearance, and the oversized Content panel wastes screen real estate. Both issues are architectural — they stem from design choices in `SpectreLayout.cs` and `SpectreLayoutDisplayService.cs` that didn't account for emoji rendering behavior or typical content density.
+
+**Root causes identified:**
+- **Border alignment**: Emojis (🗺, ⚔) are 1 character in markup but render as 2-cell width in terminals. Spectre.Console's header centering calculation doesn't account for this, causing 1-2 character misalignment.
+- **Vertical space**: Hard-coded ratio values give Content panel 50% (ratio 5/10) of screen height. At 50 rows, this allocates 25 rows to scrolling narrative text while Map/Stats get only 15 and Log/Input get 10. The Content density doesn't justify half the screen.
+
+**Recommended fixes:**
+- **Issue #1091**: Remove emojis from headers (`Floor N`, `Player Stats`) or add compensating spaces. Emoji removal preferred for cross-terminal compatibility.
+- **Issue #1092**: Reduce Content ratio from 5 to 4 (50% → 40%) and increase BottomRow ratio from 2 to 3 (20% → 30%). This gives more visible message log history without cramping the map.
+
+**Assignment:** Issues created with `bug` label, no assignee. Hill or Barton can pick up as quick wins between larger features.

--- a/Display/Spectre/SpectreLayout.cs
+++ b/Display/Spectre/SpectreLayout.cs
@@ -42,11 +42,11 @@ public static class SpectreLayout
                         new Layout(Panels.Map).Ratio(6),   // 60% width
                         new Layout(Panels.Stats).Ratio(4)  // 40% width
                     ),
-                // Middle row: 50% height — Content panel
-                new Layout(Panels.Content).Ratio(5),  // 50% of 10 units
-                // Bottom row: 20% height — Log (70%) | Input (30%)
+                // Middle row: 40% height — Content panel
+                new Layout(Panels.Content).Ratio(4),  // 40% of 10 units
+                // Bottom row: 30% height — Log (70%) | Input (30%)
                 new Layout("BottomRow")
-                    .Ratio(2)  // 20% of 10 units
+                    .Ratio(3)  // 30% of 10 units
                     .SplitColumns(
                         new Layout(Panels.Log).Ratio(7),   // 70% width
                         new Layout(Panels.Input).Ratio(3)  // 30% width
@@ -56,35 +56,35 @@ public static class SpectreLayout
         // Initialize each panel with placeholder content
         root[Panels.Map].Update(
             new Panel(new Text(""))
-                .Header("[bold green]🗺  Dungeon Map[/]")
+                .Header("[bold green]Dungeon Map[/]")
                 .Border(BoxBorder.Rounded)
                 .BorderColor(Color.Green)
         );
 
         root[Panels.Stats].Update(
             new Panel(new Text(""))
-                .Header("[bold cyan]⚔  Player Stats[/]")
+                .Header("[bold cyan]Player Stats[/]")
                 .Border(BoxBorder.Rounded)
                 .BorderColor(Color.Cyan1)
         );
 
         root[Panels.Content].Update(
             new Panel(new Text(""))
-                .Header("[bold white]📜 Adventure[/]")
+                .Header("[bold white]Adventure[/]")
                 .Border(BoxBorder.Rounded)
                 .BorderColor(Color.Blue)
         );
 
         root[Panels.Log].Update(
             new Panel(new Text(""))
-                .Header("[bold grey]📋 Message Log[/]")
+                .Header("[bold grey]Message Log[/]")
                 .Border(BoxBorder.Rounded)
                 .BorderColor(Color.Grey)
         );
 
         root[Panels.Input].Update(
             new Panel(new Text("[grey]Type commands here...[/]"))
-                .Header("[bold yellow]⌨  Command[/]")
+                .Header("[bold yellow]Command[/]")
                 .Border(BoxBorder.Rounded)
                 .BorderColor(Color.Yellow)
         );

--- a/Display/Spectre/SpectreLayoutDisplayService.cs
+++ b/Display/Spectre/SpectreLayoutDisplayService.cs
@@ -34,7 +34,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
 
     // Content panel buffer (markup strings)
     private readonly List<string> _contentLines = new();
-    private string _contentHeader = "📜 Adventure";
+    private string _contentHeader = "Adventure";
     private Color _contentBorderColor = Color.Blue;
     private const int MaxContentLines = 50;
     
@@ -118,7 +118,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
         _contentLines.Clear();
         _logHistory.Clear();
         _currentFloor = 1;
-        _contentHeader = "📜 Adventure";
+        _contentHeader = "Adventure";
         _contentBorderColor = Color.Blue;
     }
 
@@ -127,7 +127,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     private void UpdateMapPanel(string markupContent)
     {
         var panel = new Panel(new Markup(markupContent))
-            .Header($"[bold green]🗺  Floor {_currentFloor}[/]")
+            .Header($"[bold green]Floor {_currentFloor}[/]")
             .Border(BoxBorder.Rounded)
             .BorderColor(Color.Green);
         _ctx.UpdatePanel(SpectreLayout.Panels.Map, panel);
@@ -136,7 +136,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     private void UpdateStatsPanel(string markupContent)
     {
         var panel = new Panel(new Markup(markupContent))
-            .Header("[bold cyan]⚔  Player Stats[/]")
+            .Header("[bold cyan]Player Stats[/]")
             .Border(BoxBorder.Rounded)
             .BorderColor(Color.Cyan1);
         _ctx.UpdatePanel(SpectreLayout.Panels.Stats, panel);
@@ -179,7 +179,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     {
         var content = string.Join("\n", _logHistory.TakeLast(MaxLogHistory));
         var panel = new Panel(new Markup(content))
-            .Header("[bold grey]📋 Message Log[/]")
+            .Header("[bold grey]Message Log[/]")
             .Border(BoxBorder.Rounded)
             .BorderColor(Color.Grey);
         _ctx.UpdatePanel(SpectreLayout.Panels.Log, panel);
@@ -566,7 +566,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     /// <inheritdoc/>
     public void ShowCombat(string message)
     {
-        _contentHeader = "⚔  Combat";
+        _contentHeader = "Combat";
         _contentBorderColor = Color.Red;
         _contentLines.Clear();
         AppendContent($"[bold red]═══ {Markup.Escape(message)} ═══[/]");
@@ -800,7 +800,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
         }
 
         var panel = new Panel(new Markup(promptContent))
-            .Header("[bold yellow]⌨  Command[/]")
+            .Header("[bold yellow]Command[/]")
             .Border(BoxBorder.Rounded)
             .BorderColor(Color.Yellow);
         _ctx.UpdatePanel(SpectreLayout.Panels.Input, panel);
@@ -992,7 +992,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     /// <inheritdoc/>
     public void ShowCombatStart(Enemy enemy)
     {
-        _contentHeader = "⚔  Combat";
+        _contentHeader = "Combat";
         _contentBorderColor = Color.Red;
         AppendContent("");
         AppendContent("[bold red]⚔ ─── COMBAT ─── ⚔[/]");


### PR DESCRIPTION
Closes #1091
Closes #1092

## Changes

### Border alignment (#1091)
Removed emoji from all panel headers. Emoji render as 2-cell width but Spectre.Console centers headers using 1-char width, causing misalignment. Replaced all emoji headers with clean text equivalents.

### Layout ratios (#1092)
Rebalanced vertical layout ratios:
- TopRow: 30% (unchanged)
- Content: 50% → 40% (was too tall, mostly empty)
- BottomRow: 20% → 30% (more space for log and input)