### PR TITLE
fix: remove unresolvable XML cref in ContentPanelMenu doc comment

### DIFF
--- a/Display/Spectre/SpectreLayoutDisplayService.Input.cs
+++ b/Display/Spectre/SpectreLayoutDisplayService.Input.cs
@@ -542,8 +542,7 @@ public partial class SpectreLayoutDisplayService
 
     /// <summary>
     /// Renders a navigable menu to the content panel and reads keys directly,
-    /// avoiding the <see cref="Spectre.Console.DefaultExclusivityMode"/> lock
-    /// held by the Live display loop.
+    /// avoiding the DefaultExclusivityMode lock held by the Live display loop.
     /// </summary>
     private T ContentPanelMenu<T>(string title, IReadOnlyList<(string Label, T Value)> items)
     {


### PR DESCRIPTION
Removes `<see cref="Spectre.Console.DefaultExclusivityMode">` (internal Spectre type) from the ContentPanelMenu XML doc — fixes CS1574 warning introduced in PR #1125.