### PR TITLE
fix: align persistent Gear panel to match gear command output

### DIFF
--- a/Display/Spectre/SpectreLayoutDisplayService.cs
+++ b/Display/Spectre/SpectreLayoutDisplayService.cs
@@ -436,28 +436,55 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     {
         var sb = new StringBuilder();
 
-        void AddSlot(string icon, string slotName, Item? item)
+        void AddSlot(string slotLabel, Item? item, bool isWeapon = false, bool isAccessory = false)
         {
             if (item == null)
             {
-                sb.AppendLine($"[grey]{icon} {slotName}:[/] [dim](empty)[/]");
+                sb.AppendLine($"[grey]{slotLabel}:[/]  [dim](empty)[/]");
                 return;
             }
             var tc = TierColor(item.Tier);
-            var stat = PrimaryStatLabel(item);
-            sb.AppendLine($"[grey]{icon} {slotName}:[/] [{tc}]{Markup.Escape(item.Name)}[/] [grey]{Markup.Escape(stat)}[/]");
+            var statParts = new List<string>();
+            if (isWeapon)
+            {
+                if (item.AttackBonus  != 0) statParts.Add($"[red]+{item.AttackBonus} ATK[/]");
+                if (item.DodgeBonus   >  0) statParts.Add($"[yellow]+{item.DodgeBonus:P0} dodge[/]");
+                if (item.MaxManaBonus >  0) statParts.Add($"[blue]+{item.MaxManaBonus} mana[/]");
+            }
+            else if (isAccessory)
+            {
+                if (item.AttackBonus  != 0) statParts.Add($"[red]+{item.AttackBonus} ATK[/]");
+                if (item.DefenseBonus != 0) statParts.Add($"[cyan]+{item.DefenseBonus} DEF[/]");
+                if (item.StatModifier != 0) statParts.Add($"[green]+{item.StatModifier} HP[/]");
+                if (item.DodgeBonus   >  0) statParts.Add($"[yellow]+{item.DodgeBonus:P0} dodge[/]");
+            }
+            else
+            {
+                if (item.DefenseBonus != 0) statParts.Add($"[cyan]+{item.DefenseBonus} DEF[/]");
+                if (item.DodgeBonus   >  0) statParts.Add($"[yellow]+{item.DodgeBonus:P0} dodge[/]");
+                if (item.MaxManaBonus >  0) statParts.Add($"[blue]+{item.MaxManaBonus} mana[/]");
+            }
+            var statsStr = statParts.Count > 0 ? "  " + string.Join(", ", statParts) : "";
+            sb.AppendLine($"[grey]{slotLabel}:[/]  [{tc}]{Markup.Escape(item.Name)}[/]{statsStr}");
         }
 
-        AddSlot("⚔",  "Weapon",    player.EquippedWeapon);
-        AddSlot("💍", "Accessory", player.EquippedAccessory);
-        AddSlot("🪖", "Head",      player.EquippedHead);
-        AddSlot("🥋", "Shoulders", player.EquippedShoulders);
-        AddSlot("🦺", "Chest",     player.EquippedChest);
-        AddSlot("🧤", "Hands",     player.EquippedHands);
-        AddSlot("👖", "Legs",      player.EquippedLegs);
-        AddSlot("👟", "Feet",      player.EquippedFeet);
-        AddSlot("🧥", "Back",      player.EquippedBack);
-        AddSlot("🔰", "Off-Hand",  player.EquippedOffHand);
+        AddSlot("⚔  Weapon",    player.EquippedWeapon,    isWeapon: true);
+        AddSlot("💍 Accessory", player.EquippedAccessory, isAccessory: true);
+        AddSlot("🪖 Head",      player.EquippedHead);
+        AddSlot("🥋 Shoulders", player.EquippedShoulders);
+        AddSlot("🦺 Chest",     player.EquippedChest);
+        AddSlot("🧤 Hands",     player.EquippedHands);
+        AddSlot("👖 Legs",      player.EquippedLegs);
+        AddSlot("👟 Feet",      player.EquippedFeet);
+        AddSlot("🧥 Back",      player.EquippedBack);
+        AddSlot("🔰 Off-Hand",  player.EquippedOffHand);
+
+        var setDesc = SetBonusManager.GetActiveBonusDescription(player);
+        if (!string.IsNullOrEmpty(setDesc))
+        {
+            sb.AppendLine();
+            sb.Append($"[yellow]Set Bonus: {Markup.Escape(setDesc)}[/]");
+        }
 
         var panel = new Panel(new Markup(sb.ToString().TrimEnd()))
             .Header("[bold yellow]⚔  Gear[/]")


### PR DESCRIPTION
Closes #1127

The persistent Gear panel now uses the same stat rendering logic as the gear/equipment command:
- Slot-specific colored stats (ATK in red, DEF in cyan, dodge in yellow, mana in blue, HP in green)
- Tier-colored item names
- Set bonus displayed at the bottom

This makes both views consistent — the panel always shows what the command would show.