### PR TITLE
fix: merchant menu bugs — sell loop, room restore, escape fix

### DIFF
--- a/Display/Spectre/SpectreLayoutDisplayService.Input.cs
+++ b/Display/Spectre/SpectreLayoutDisplayService.Input.cs
@@ -582,7 +582,7 @@ public partial class SpectreLayoutDisplayService
                     return items[selected].Value;
                 case System.ConsoleKey.Escape:
                 case System.ConsoleKey.Q:
-                    return items[selected].Value;
+                    return items[items.Count - 1].Value;
             }
         }
     }

--- a/Dungnz.Tests/Helpers/FakeDisplayService.cs
+++ b/Dungnz.Tests/Helpers/FakeDisplayService.cs
@@ -17,6 +17,11 @@ public class FakeDisplayService : IDisplayService
     public List<string> CombatMessages { get; } = new();
     public List<string> RawCombatMessages { get; } = new();
     public List<string> AllOutput { get; } = new();
+    
+    public int ShowRoomCallCount { get; private set; }
+    public Queue<int>? SellMenuSelectResponses { get; set; }
+    public Queue<bool>? ConfirmMenuResponses { get; set; }
+    public Queue<int>? ShopMenuSelectResponses { get; set; }
 
     /// <summary>
     /// Strips ANSI color codes from text to ensure tests check plain text content.
@@ -26,7 +31,11 @@ public class FakeDisplayService : IDisplayService
     public void ShowTitle() { }
     public void ShowCommandPrompt(Player? player = null) { }
     public void ShowHelp() { AllOutput.Add("help"); }
-    public void ShowRoom(Room room) { AllOutput.Add($"room:{room.Description}"); }
+    public void ShowRoom(Room room) 
+    { 
+        ShowRoomCallCount++;
+        AllOutput.Add($"room:{room.Description}"); 
+    }
     public void ShowMap(Room room, int floor = 1) { AllOutput.Add($"map:{room.Description}"); }
     public string ReadPlayerName() => "TestPlayer";
     public string? ReadCommandInput() => _input?.ReadLine()?.Trim();
@@ -162,6 +171,13 @@ public class FakeDisplayService : IDisplayService
     public int ShowSellMenuAndSelect(IEnumerable<(Item item, int sellPrice)> items, int playerGold)
     {
         AllOutput.Add($"sell_select:{playerGold}g");
+        
+        // Check if queue-based responses are configured
+        if (SellMenuSelectResponses != null && SellMenuSelectResponses.Count > 0)
+        {
+            return SellMenuSelectResponses.Dequeue();
+        }
+        
         if (_input is not null)
         {
             var line = _input.ReadLine()?.Trim() ?? "";
@@ -198,6 +214,13 @@ public class FakeDisplayService : IDisplayService
     public int ShowShopWithSellAndSelect(IEnumerable<(Item item, int price)> stock, int playerGold)
     {
         AllOutput.Add($"shop_with_sell:{playerGold}g");
+        
+        // Check if queue-based responses are configured
+        if (ShopMenuSelectResponses != null && ShopMenuSelectResponses.Count > 0)
+        {
+            return ShopMenuSelectResponses.Dequeue();
+        }
+        
         if (_input is not null)
         {
             var line = _input.ReadLine()?.Trim() ?? "";
@@ -208,6 +231,13 @@ public class FakeDisplayService : IDisplayService
     public bool ShowConfirmMenu(string prompt)
     {
         AllOutput.Add($"confirm:{prompt}");
+        
+        // Check if queue-based responses are configured
+        if (ConfirmMenuResponses != null && ConfirmMenuResponses.Count > 0)
+        {
+            return ConfirmMenuResponses.Dequeue();
+        }
+        
         if (_input is not null)
         {
             var line = _input.ReadLine()?.Trim().ToUpperInvariant() ?? "";

--- a/Dungnz.Tests/SellSystemTests.cs
+++ b/Dungnz.Tests/SellSystemTests.cs
@@ -259,4 +259,145 @@ public class SellSystemTests
         player.Gold.Should().Be(0, "no gold should be awarded on cancel");
         display.Messages.Should().Contain("Changed your mind.");
     }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Test Group 1 — ShowRoom restoration (#1157)
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sell_Success_CallsShowRoom()
+    {
+        var (player, room, display, loop) = MakeSellSetup("sell", "1", "Y", "quit");
+        var potion = new Item { Name = "Health Potion", Type = ItemType.Consumable, Tier = ItemTier.Common };
+        player.Inventory.Add(potion);
+
+        loop.Run(player, room);
+
+        display.ShowRoomCallCount.Should().BeGreaterThan(0, "ShowRoom should be called after successful sale");
+    }
+
+    [Fact]
+    public void Sell_Cancel_CallsShowRoom()
+    {
+        var (player, room, display, loop) = MakeSellSetup("sell", "quit");
+        var potion = new Item { Name = "Health Potion", Type = ItemType.Consumable, Tier = ItemTier.Common };
+        player.Inventory.Add(potion);
+
+        int initialShowRoomCount = display.ShowRoomCallCount;
+        loop.Run(player, room);
+
+        display.ShowRoomCallCount.Should().BeGreaterThan(initialShowRoomCount, "ShowRoom should be called when player cancels at sell menu");
+    }
+
+    [Fact]
+    public void Sell_NoItems_CallsShowRoom()
+    {
+        var (player, room, display, loop) = MakeSellSetup("sell", "quit");
+
+        int initialShowRoomCount = display.ShowRoomCallCount;
+        loop.Run(player, room);
+
+        display.ShowRoomCallCount.Should().BeGreaterThan(initialShowRoomCount, "ShowRoom should be called when inventory has no sellable items");
+    }
+
+    [Fact]
+    public void Sell_NoMerchant_DoesNotCallShowRoom()
+    {
+        var display = new FakeDisplayService();
+        var combat = new Mock<ICombatEngine>();
+        var reader = new FakeInputReader("sell", "quit");
+        var loop = new GameLoop(display, combat.Object, reader);
+
+        var player = new Player { Name = "Tester", HP = 100, MaxHP = 100, Attack = 10, Defense = 5 };
+        var room = new Room { Description = "Empty room" };
+        var potion = new Item { Name = "Health Potion", Type = ItemType.Consumable };
+        player.Inventory.Add(potion);
+
+        int initialShowRoomCount = display.ShowRoomCallCount;
+        loop.Run(player, room);
+
+        display.ShowRoomCallCount.Should().Be(initialShowRoomCount + 1, "ShowRoom should only be called once by RefreshDisplay, not by SellCommandHandler on error path (no merchant)");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Test Group 2 — Multi-sell loop (#1158)
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sell_CanSellMultipleItems_InOneSession()
+    {
+        var (player, room, display, loop) = MakeSellSetup("sell", "quit");
+        
+        var potion1 = new Item { Name = "Health Potion", Type = ItemType.Consumable, Tier = ItemTier.Common };
+        var potion2 = new Item { Name = "Mana Potion", Type = ItemType.Consumable, Tier = ItemTier.Common };
+        player.Inventory.Add(potion1);
+        player.Inventory.Add(potion2);
+
+        int expectedPrice1 = MerchantInventoryConfig.ComputeSellPrice(potion1);
+        int expectedPrice2 = MerchantInventoryConfig.ComputeSellPrice(potion2);
+
+        display.SellMenuSelectResponses = new Queue<int>(new[] { 1, 1, 0 });
+        display.ConfirmMenuResponses = new Queue<bool>(new[] { true, true });
+
+        loop.Run(player, room);
+
+        player.Inventory.Should().NotContain(potion1, "first item should be sold");
+        player.Inventory.Should().NotContain(potion2, "second item should be sold");
+        player.Gold.Should().Be(expectedPrice1 + expectedPrice2, "both items should award gold");
+    }
+
+    [Fact]
+    public void Sell_AfterCancelConfirm_ContinuesLoop()
+    {
+        var (player, room, display, loop) = MakeSellSetup("sell", "quit");
+        
+        var potion = new Item { Name = "Health Potion", Type = ItemType.Consumable, Tier = ItemTier.Common };
+        player.Inventory.Add(potion);
+
+        int expectedPrice = MerchantInventoryConfig.ComputeSellPrice(potion);
+
+        display.SellMenuSelectResponses = new Queue<int>(new[] { 1, 1, 0 });
+        display.ConfirmMenuResponses = new Queue<bool>(new[] { false, true });
+
+        loop.Run(player, room);
+
+        player.Inventory.Should().NotContain(potion, "item should be sold after second attempt");
+        player.Gold.Should().Be(expectedPrice, "gold should be awarded after confirming");
+        display.Messages.Should().Contain("Changed your mind.", "cancel message should appear after first NO");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Test Group 3 — Shop ShowRoom restoration (#1156)
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Shop_Leave_CallsShowRoom()
+    {
+        var (player, room, display, loop) = MakeSellSetup("shop", "quit");
+
+        display.ShopMenuSelectResponses = new Queue<int>(new[] { 0 });
+
+        int initialShowRoomCount = display.ShowRoomCallCount;
+        loop.Run(player, room);
+
+        display.ShowRoomCallCount.Should().BeGreaterThan(initialShowRoomCount, "ShowRoom should be called when player selects Leave (0)");
+    }
+
+    [Fact]
+    public void Shop_NoMerchant_Error_NoShowRoom()
+    {
+        var display = new FakeDisplayService();
+        var combat = new Mock<ICombatEngine>();
+        var reader = new FakeInputReader("shop", "quit");
+        var loop = new GameLoop(display, combat.Object, reader);
+
+        var player = new Player { Name = "Tester", HP = 100, MaxHP = 100, Attack = 10, Defense = 5 };
+        var room = new Room { Description = "Empty room" };
+
+        int initialShowRoomCount = display.ShowRoomCallCount;
+        loop.Run(player, room);
+
+        display.Errors.Should().Contain(e => e.Contains("no merchant"), "error should be shown when no merchant");
+        display.ShowRoomCallCount.Should().Be(initialShowRoomCount + 1, "ShowRoom should only be called once by RefreshDisplay, not by ShopCommandHandler on error path (no merchant)");
+    }
 }

--- a/Engine/Commands/SellCommandHandler.cs
+++ b/Engine/Commands/SellCommandHandler.cs
@@ -13,37 +13,42 @@ internal sealed class SellCommandHandler : ICommandHandler
             return;
         }
 
-        // Items in player.Inventory are already unequipped; exclude Gold-type items
-        var sellable = context.Player.Inventory
-            .Where(i => i.Type != ItemType.Gold)
-            .ToList();
-
-        if (!sellable.Any())
+        while (true)
         {
-            context.Display.ShowMessage(MerchantNarration.GetNoSell());
-            return;
+            // Items in player.Inventory are already unequipped; exclude Gold-type items
+            var sellable = context.Player.Inventory
+                .Where(i => i.Type != ItemType.Gold)
+                .ToList();
+
+            if (!sellable.Any())
+            {
+                context.Display.ShowMessage(MerchantNarration.GetNoSell());
+                break;
+            }
+
+            var idx = context.Display.ShowSellMenuAndSelect(sellable.Select(i => (i, MerchantInventoryConfig.ComputeSellPrice(i))), context.Player.Gold);
+            if (idx == 0)
+                break;
+
+            var item = sellable[idx - 1];
+            int price = MerchantInventoryConfig.ComputeSellPrice(item);
+
+            if (!context.Display.ShowConfirmMenu($"Sell {item.Name} for {price}g?"))
+            {
+                context.Display.ShowMessage("Changed your mind.");
+                continue;
+            }
+
+            context.Player.Inventory.Remove(item);
+            context.Player.AddGold(price);
+            context.Display.ShowMessage($"You sold {item.Name} for {price}g. Gold remaining: {context.Player.Gold}g");
+            context.Display.ShowPlayerStats(context.Player);
+            if (item.Tier == ItemTier.Legendary)
+                context.Display.ShowMessage(MerchantNarration.GetLegendarySold());
+            else
+                context.Display.ShowMessage(MerchantNarration.GetAfterSale());
         }
 
-        var idx = context.Display.ShowSellMenuAndSelect(sellable.Select(i => (i, MerchantInventoryConfig.ComputeSellPrice(i))), context.Player.Gold);
-        if (idx == 0)
-            return;
-
-        var item = sellable[idx - 1];
-        int price = MerchantInventoryConfig.ComputeSellPrice(item);
-
-        if (!context.Display.ShowConfirmMenu($"Sell {item.Name} for {price}g?"))
-        {
-            context.Display.ShowMessage("Changed your mind.");
-            return;
-        }
-
-        context.Player.Inventory.Remove(item);
-        context.Player.AddGold(price);
-        context.Display.ShowMessage($"You sold {item.Name} for {price}g. Gold remaining: {context.Player.Gold}g");
-        context.Display.ShowPlayerStats(context.Player);
-        if (item.Tier == ItemTier.Legendary)
-            context.Display.ShowMessage(MerchantNarration.GetLegendarySold());
-        else
-            context.Display.ShowMessage(MerchantNarration.GetAfterSale());
+        context.Display.ShowRoom(context.CurrentRoom);
     }
 }

--- a/Engine/Commands/ShopCommandHandler.cs
+++ b/Engine/Commands/ShopCommandHandler.cs
@@ -27,6 +27,7 @@ internal sealed class ShopCommandHandler : ICommandHandler
             {
                 context.Display.ShowMessage("You leave the shop.");
                 context.Display.ShowMessage(context.Narration.Pick(MerchantNarration.NoBuy));
+                context.Display.ShowRoom(context.CurrentRoom);
                 return;
             }
 


### PR DESCRIPTION
Closes #1156
Closes #1157
Closes #1158
Closes #1159

## Changes
- **SellCommandHandler**: Add multi-sell loop (sell multiple items per command invocation)
- **SellCommandHandler**: Call ShowRoom() on all non-error exit paths to restore content panel
- **ShopCommandHandler**: Call ShowRoom() when player selects Leave to restore content panel  
- **ContentPanelMenu**: Escape/Q now selects last item (cancel) instead of current selection
- **Tests**: Add 8 new tests validating sell/shop ShowRoom behavior and multi-sell loop
- **Tests**: Fix RefreshDisplay accounting in NoMerchant tests (GameLoop.Run() calls RefreshDisplay → ShowRoom once at startup)

## Testing
- All 1695 tests pass
- 42 sell/shop tests now validate the fixes