### PR TITLE
fix: add missing ShowRoom() on error paths in command handlers

### DIFF
--- a/Dungnz.Tests/MenuRestorationTests.cs
+++ b/Dungnz.Tests/MenuRestorationTests.cs
@@ -127,7 +127,7 @@ public class MenuRestorationTests
     }
 
     [Fact]
-    public void UseCommandHandler_NoUsableItems_DoesNotCallShowRoom()
+    public void UseCommandHandler_NoUsableItems_CallsShowRoom()
     {
         var display = new FakeDisplayService();
         var player = new Player { Name = "Tester", HP = 100, MaxHP = 100 };
@@ -140,8 +140,8 @@ public class MenuRestorationTests
 
         handler.Handle(string.Empty, ctx);
 
-        display.ShowRoomCallCount.Should().Be(initialShowRoomCount, 
-            "ShowRoom should not be called when there are no usable items (early return)");
+        display.ShowRoomCallCount.Should().BeGreaterThan(initialShowRoomCount, 
+            "ShowRoom should be called even when there are no usable items, to prevent stale display");
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -207,7 +207,7 @@ public class MenuRestorationTests
     }
 
     [Fact]
-    public void ExamineCommandHandler_ItemNotFound_DoesNotCallShowRoom()
+    public void ExamineCommandHandler_ItemNotFound_CallsShowRoom()
     {
         var display = new FakeDisplayService();
         var player = new Player { Name = "Tester", HP = 100, MaxHP = 100 };
@@ -218,8 +218,8 @@ public class MenuRestorationTests
 
         handler.Handle("nonexistent", ctx);
 
-        display.ShowRoomCallCount.Should().Be(initialShowRoomCount, 
-            "ShowRoom should not be called when item is not found (error path)");
+        display.ShowRoomCallCount.Should().BeGreaterThan(initialShowRoomCount, 
+            "ShowRoom should be called when item is not found, to prevent stale display");
     }
 
     // ────────────────────────────────────────────────────────────────────────

--- a/Engine/Commands/CompareCommandHandler.cs
+++ b/Engine/Commands/CompareCommandHandler.cs
@@ -34,6 +34,7 @@ internal sealed class CompareCommandHandler : ICommandHandler
         {
             context.TurnConsumed = false;
             context.Display.ShowError($"You don't have '{argument}' in your inventory.");
+            context.Display.ShowRoom(context.CurrentRoom);
             return;
         }
 
@@ -41,6 +42,7 @@ internal sealed class CompareCommandHandler : ICommandHandler
         {
             context.TurnConsumed = false;
             context.Display.ShowError($"{item.Name} cannot be equipped, so there's nothing to compare.");
+            context.Display.ShowRoom(context.CurrentRoom);
             return;
         }
 

--- a/Engine/Commands/CraftCommandHandler.cs
+++ b/Engine/Commands/CraftCommandHandler.cs
@@ -52,6 +52,7 @@ internal sealed class CraftCommandHandler : ICommandHandler
         {
             context.TurnConsumed = false;
             context.Display.ShowError($"Unknown recipe: {argument}");
+            context.Display.ShowRoom(context.CurrentRoom);
             return;
         }
 
@@ -62,5 +63,6 @@ internal sealed class CraftCommandHandler : ICommandHandler
             context.Display.ShowPlayerStats(context.Player);
         }
         else context.Display.ShowError(msg2);
+        context.Display.ShowRoom(context.CurrentRoom);
     }
 }

--- a/Engine/Commands/ExamineCommandHandler.cs
+++ b/Engine/Commands/ExamineCommandHandler.cs
@@ -8,6 +8,7 @@ internal sealed class ExamineCommandHandler : ICommandHandler
         {
             context.TurnConsumed = false;
             context.Display.ShowError("Examine what?");
+            context.Display.ShowRoom(context.CurrentRoom);
             return;
         }
 
@@ -18,6 +19,7 @@ internal sealed class ExamineCommandHandler : ICommandHandler
             context.CurrentRoom.Enemy.Name.ToLowerInvariant().Contains(targetLower))
         {
             context.Display.ShowMessage($"{context.CurrentRoom.Enemy.Name} - HP: {context.CurrentRoom.Enemy.HP}/{context.CurrentRoom.Enemy.MaxHP}, Attack: {context.CurrentRoom.Enemy.Attack}, Defense: {context.CurrentRoom.Enemy.Defense}");
+            context.Display.ShowRoom(context.CurrentRoom);
             return;
         }
 
@@ -49,5 +51,6 @@ internal sealed class ExamineCommandHandler : ICommandHandler
 
         context.TurnConsumed = false;
         context.Display.ShowError($"You don't see any '{argument}' here.");
+        context.Display.ShowRoom(context.CurrentRoom);
     }
 }

--- a/Engine/Commands/SkillsCommandHandler.cs
+++ b/Engine/Commands/SkillsCommandHandler.cs
@@ -38,6 +38,7 @@ internal sealed class LearnCommandHandler : ICommandHandler
         {
             context.TurnConsumed = false;
             context.Display.ShowError($"Unknown skill: {argument}");
+            context.Display.ShowRoom(context.CurrentRoom);
             return;
         }
         new SkillsCommandHandler().HandleLearnSpecificSkill(skill, context);

--- a/Engine/Commands/UseCommandHandler.cs
+++ b/Engine/Commands/UseCommandHandler.cs
@@ -14,6 +14,7 @@ internal sealed class UseCommandHandler : ICommandHandler
             if (usable.Count == 0)
             {
                 context.Display.ShowError("You have no usable items in your inventory.");
+                context.Display.ShowRoom(context.CurrentRoom);
                 return;
             }
             var selected = context.Display.ShowUseMenuAndSelect(usable.AsReadOnly());
@@ -51,6 +52,7 @@ internal sealed class UseCommandHandler : ICommandHandler
             {
                 context.TurnConsumed = false;
                 context.Display.ShowError($"You don't have '{argument}'.");
+                context.Display.ShowRoom(context.CurrentRoom);
                 return;
             }
 
@@ -62,6 +64,7 @@ internal sealed class UseCommandHandler : ICommandHandler
                 context.TurnConsumed = false;
                 var names = string.Join(", ", bestCandidates.Select(x => x.Item.Name));
                 context.Display.ShowError($"Did you mean one of: {names}? Please be more specific.");
+                context.Display.ShowRoom(context.CurrentRoom);
                 return;
             }
 
@@ -185,9 +188,6 @@ internal sealed class UseCommandHandler : ICommandHandler
                 break;
         }
         
-        if (context.TurnConsumed)
-        {
-            context.Display.ShowRoom(context.CurrentRoom);
-        }
+        context.Display.ShowRoom(context.CurrentRoom);
     }
 }


### PR DESCRIPTION
## Summary
Adds missing ShowRoom() calls on error and early-return paths in 5 command handlers, fixing stale display state after errors.

## Changes
- ExamineCommandHandler: ShowRoom on enemy examine, 'Examine what?' error, 'don't see it' error
- CompareCommandHandler: ShowRoom on item-not-found and not-equippable errors
- CraftCommandHandler: ShowRoom on unknown-recipe error and direct-craft result
- UseCommandHandler: ShowRoom on no-items, not-found, ambiguous-match early returns; always calls ShowRoom at bottom (fixes Weapon/Armor/CraftingMaterial/default switch paths)
- LearnCommandHandler: ShowRoom on unknown-skill error

Also updates two MenuRestorationTests that were asserting the old buggy DoesNotCallShowRoom behavior on the now-fixed paths.

Closes #1177