### PR TITLE
feat: scaffold CombatEngine decomposition classes (#1203)

### DIFF
--- a/Dungnz.Engine/AbilityProcessor.cs
+++ b/Dungnz.Engine/AbilityProcessor.cs
@@ -1,0 +1,34 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+
+/// <summary>
+/// Stub implementation of <see cref="IAbilityProcessor"/>. Logic will be migrated from
+/// <see cref="CombatEngine"/> in a follow-up decomposition task.
+/// </summary>
+public class AbilityProcessor : IAbilityProcessor
+{
+    private readonly IDisplayService _display;
+    private readonly AbilityManager _abilities;
+    private readonly StatusEffectManager _statusEffects;
+    private readonly InventoryManager _inventoryManager;
+
+    /// <summary>Initialises a new <see cref="AbilityProcessor"/> with the required dependencies.</summary>
+    public AbilityProcessor(
+        IDisplayService display,
+        AbilityManager abilities,
+        StatusEffectManager statusEffects,
+        InventoryManager inventoryManager)
+    {
+        _display = display;
+        _abilities = abilities;
+        _statusEffects = statusEffects;
+        _inventoryManager = inventoryManager;
+    }
+
+    /// <inheritdoc/>
+    public AbilityMenuResult HandleAbilityMenu(Player player, Enemy enemy) => AbilityMenuResult.Cancel;
+
+    /// <inheritdoc/>
+    public AbilityMenuResult HandleItemMenu(Player player, Enemy enemy) => AbilityMenuResult.Cancel;
+}

--- a/Dungnz.Engine/AttackResolver.cs
+++ b/Dungnz.Engine/AttackResolver.cs
@@ -1,0 +1,40 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+
+/// <summary>
+/// Stub implementation of <see cref="IAttackResolver"/>. Logic will be migrated from
+/// <see cref="CombatEngine"/> in a follow-up decomposition task.
+/// </summary>
+public class AttackResolver : IAttackResolver
+{
+    private readonly IDisplayService _display;
+    private readonly Random _rng;
+    private readonly StatusEffectManager _statusEffects;
+    private readonly NarrationService _narration;
+
+    /// <summary>Initialises a new <see cref="AttackResolver"/> with the required dependencies.</summary>
+    public AttackResolver(
+        IDisplayService display,
+        Random rng,
+        StatusEffectManager statusEffects,
+        NarrationService narration)
+    {
+        _display = display;
+        _rng = rng;
+        _statusEffects = statusEffects;
+        _narration = narration;
+    }
+
+    /// <inheritdoc/>
+    public void PerformPlayerAttack(Player player, Enemy enemy) { }
+
+    /// <inheritdoc/>
+    public bool RollDodge(int defense) => false;
+
+    /// <inheritdoc/>
+    public bool RollPlayerDodge(Player player) => false;
+
+    /// <inheritdoc/>
+    public bool RollCrit(Player? player = null) => false;
+}

--- a/Dungnz.Engine/CombatEngine.cs
+++ b/Dungnz.Engine/CombatEngine.cs
@@ -23,6 +23,12 @@ public class CombatEngine : ICombatEngine
     private readonly PassiveEffectProcessor _passives;
     private readonly DifficultySettings _difficulty;
     private readonly List<CombatTurn> _turnLog = new();
+
+    // Decomposition stubs — see #1203; logic migration follows in subsequent tasks
+    private readonly IAttackResolver _attackResolver;
+    private readonly IAbilityProcessor _abilityProcessor;
+    private readonly IStatusEffectApplicator _statusEffectApplicator;
+    private readonly ICombatLogger _combatLogger;
     private RunStats _stats = new();
     private int _baseEliteAttack;
     private int _baseEliteDefense;
@@ -78,7 +84,7 @@ public class CombatEngine : ICombatEngine
     /// Optional difficulty settings applied to damage scaling and flee mechanics.
     /// Defaults to <see cref="Difficulty.Normal"/> when <see langword="null"/>.
     /// </param>
-    public CombatEngine(IDisplayService display, IInputReader? input = null, Random? rng = null, GameEvents? events = null, StatusEffectManager? statusEffects = null, AbilityManager? abilities = null, NarrationService? narration = null, InventoryManager? inventoryManager = null, IMenuNavigator? navigator = null, DifficultySettings? difficulty = null)
+    public CombatEngine(IDisplayService display, IInputReader? input = null, Random? rng = null, GameEvents? events = null, StatusEffectManager? statusEffects = null, AbilityManager? abilities = null, NarrationService? narration = null, InventoryManager? inventoryManager = null, IMenuNavigator? navigator = null, DifficultySettings? difficulty = null, IAttackResolver? attackResolver = null, IAbilityProcessor? abilityProcessor = null, IStatusEffectApplicator? statusEffectApplicator = null, ICombatLogger? combatLogger = null)
     {
         _display = display;
         _input = input ?? new ConsoleInputReader();
@@ -91,6 +97,10 @@ public class CombatEngine : ICombatEngine
         _navigator = navigator;
         _difficulty = difficulty ?? DifficultySettings.For(Difficulty.Normal);
         _passives = new PassiveEffectProcessor(_display, _rng, _statusEffects);
+        _attackResolver = attackResolver ?? new AttackResolver(_display, _rng, _statusEffects, _narration);
+        _abilityProcessor = abilityProcessor ?? new AbilityProcessor(_display, _abilities, _statusEffects, _inventoryManager);
+        _statusEffectApplicator = statusEffectApplicator ?? new StatusEffectApplicator(_display, _rng, _statusEffects);
+        _combatLogger = combatLogger ?? new CombatLogger(_display, _narration);
     }
 
     /// <summary>

--- a/Dungnz.Engine/CombatLogger.cs
+++ b/Dungnz.Engine/CombatLogger.cs
@@ -1,0 +1,33 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+using System.Collections.Generic;
+
+/// <summary>
+/// Stub implementation of <see cref="ICombatLogger"/>. Logic will be migrated from
+/// <see cref="CombatEngine"/> in a follow-up decomposition task.
+/// </summary>
+public class CombatLogger : ICombatLogger
+{
+    private readonly IDisplayService _display;
+    private readonly NarrationService _narration;
+
+    /// <summary>Initialises a new <see cref="CombatLogger"/> with the required dependencies.</summary>
+    public CombatLogger(IDisplayService display, NarrationService narration)
+    {
+        _display = display;
+        _narration = narration;
+    }
+
+    /// <inheritdoc/>
+    public string ColorizeDamage(string message, int damage, bool isCrit = false, bool isHealing = false) => message;
+
+    /// <inheritdoc/>
+    public void ShowDeathNarration(Enemy enemy) { }
+
+    /// <inheritdoc/>
+    public void LogTurn(IList<CombatTurn> turnLog, CombatTurn turn) { }
+
+    /// <inheritdoc/>
+    public void ShowRecentTurns(IReadOnlyList<CombatTurn> turnLog) { }
+}

--- a/Dungnz.Engine/IAbilityProcessor.cs
+++ b/Dungnz.Engine/IAbilityProcessor.cs
@@ -1,0 +1,16 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+
+/// <summary>
+/// Handles skill and ability usage during combat, including presenting the ability
+/// and item menus to the player and executing the selected action.
+/// </summary>
+public interface IAbilityProcessor
+{
+    /// <summary>Presents the ability selection menu and executes the chosen ability.</summary>
+    AbilityMenuResult HandleAbilityMenu(Player player, Enemy enemy);
+
+    /// <summary>Presents the in-combat item menu and uses the selected consumable.</summary>
+    AbilityMenuResult HandleItemMenu(Player player, Enemy enemy);
+}

--- a/Dungnz.Engine/IAttackResolver.cs
+++ b/Dungnz.Engine/IAttackResolver.cs
@@ -1,0 +1,22 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+
+/// <summary>
+/// Handles all attack calculation logic for combat, including hit/dodge/crit rolls
+/// and damage application for both player and enemy attacks.
+/// </summary>
+public interface IAttackResolver
+{
+    /// <summary>Resolves the player attack action against the enemy for one turn.</summary>
+    void PerformPlayerAttack(Player player, Enemy enemy);
+
+    /// <summary>Rolls a dodge check using the given defense value.</summary>
+    bool RollDodge(int defense);
+
+    /// <summary>Rolls a dodge check for the player, incorporating equipment and class bonuses.</summary>
+    bool RollPlayerDodge(Player player);
+
+    /// <summary>Rolls a critical hit check, optionally incorporating player equipment bonuses.</summary>
+    bool RollCrit(Player? player = null);
+}

--- a/Dungnz.Engine/ICombatLogger.cs
+++ b/Dungnz.Engine/ICombatLogger.cs
@@ -1,0 +1,26 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+using System.Collections.Generic;
+
+/// <summary>
+/// Handles all combat message formatting and logging, including damage colorisation,
+/// turn history, and enemy death narration.
+/// </summary>
+public interface ICombatLogger
+{
+    /// <summary>
+    /// Colorizes damage values in a combat message. Damage is rendered in red, healing
+    /// in green, and critical hits in bold yellow.
+    /// </summary>
+    string ColorizeDamage(string message, int damage, bool isCrit = false, bool isHealing = false);
+
+    /// <summary>Displays the enemy death narration via the display service.</summary>
+    void ShowDeathNarration(Enemy enemy);
+
+    /// <summary>Appends a turn record to the running turn log.</summary>
+    void LogTurn(IList<CombatTurn> turnLog, CombatTurn turn);
+
+    /// <summary>Displays the most recent turns from the combat log.</summary>
+    void ShowRecentTurns(IReadOnlyList<CombatTurn> turnLog);
+}

--- a/Dungnz.Engine/IStatusEffectApplicator.cs
+++ b/Dungnz.Engine/IStatusEffectApplicator.cs
@@ -1,0 +1,22 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+
+/// <summary>
+/// Handles applying and evaluating status effects triggered by combat events such as
+/// enemy death, boss revival checks, and end-of-combat cleanup.
+/// </summary>
+public interface IStatusEffectApplicator
+{
+    /// <summary>Applies on-death status effects from the enemy to the player (e.g. CursedZombie Weakened).</summary>
+    void ApplyOnDeathEffects(Player player, Enemy enemy);
+
+    /// <summary>
+    /// Checks whether the enemy should revive or trigger on-death mechanics.
+    /// Returns true if the enemy revived and combat should continue.
+    /// </summary>
+    bool CheckOnDeathEffects(Player player, Enemy enemy, Random rng);
+
+    /// <summary>Clears all transient combat status effects from both combatants at the end of a fight.</summary>
+    void ResetCombatEffects(Player player, Enemy enemy);
+}

--- a/Dungnz.Engine/StatusEffectApplicator.cs
+++ b/Dungnz.Engine/StatusEffectApplicator.cs
@@ -1,0 +1,34 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems;
+
+/// <summary>
+/// Stub implementation of <see cref="IStatusEffectApplicator"/>. Logic will be migrated from
+/// <see cref="CombatEngine"/> in a follow-up decomposition task.
+/// </summary>
+public class StatusEffectApplicator : IStatusEffectApplicator
+{
+    private readonly IDisplayService _display;
+    private readonly Random _rng;
+    private readonly StatusEffectManager _statusEffects;
+
+    /// <summary>Initialises a new <see cref="StatusEffectApplicator"/> with the required dependencies.</summary>
+    public StatusEffectApplicator(
+        IDisplayService display,
+        Random rng,
+        StatusEffectManager statusEffects)
+    {
+        _display = display;
+        _rng = rng;
+        _statusEffects = statusEffects;
+    }
+
+    /// <inheritdoc/>
+    public void ApplyOnDeathEffects(Player player, Enemy enemy) { }
+
+    /// <inheritdoc/>
+    public bool CheckOnDeathEffects(Player player, Enemy enemy, Random rng) => false;
+
+    /// <inheritdoc/>
+    public void ResetCombatEffects(Player player, Enemy enemy) { }
+}


### PR DESCRIPTION
## Summary
Scaffolds the four new focused classes (AttackResolver, AbilityProcessor, StatusEffectApplicator, CombatLogger) with their interfaces as a foundation for decomposing CombatEngine.

No logic is moved — this establishes the structure and constructor wiring.

## Changes
- Added IAttackResolver + AttackResolver
- Added IAbilityProcessor + AbilityProcessor
- Added IStatusEffectApplicator + StatusEffectApplicator
- Added ICombatLogger + CombatLogger
- CombatEngine wired to accept these via constructor

Closes #1203