### PR TITLE
feat: IEnemyAI interface + GoblinAI, SkeletonAI implementations (#1209)

### DIFF
--- a/Dungnz.Engine/EnemyAIRegistry.cs
+++ b/Dungnz.Engine/EnemyAIRegistry.cs
@@ -1,0 +1,35 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+using Dungnz.Systems.Enemies;
+
+/// <summary>
+/// Registry that maps enemy types to their AI implementations.
+/// Provides a centralized lookup for enemy combat behaviors.
+/// </summary>
+public static class EnemyAIRegistry
+{
+    private static readonly Dictionary<Type, IEnemyAI> _aiByType = new()
+    {
+        { typeof(Goblin), new GoblinAI() },
+        { typeof(Skeleton), new SkeletonAI() }
+    };
+    
+    /// <summary>
+    /// Gets the AI implementation for the given enemy, or null if none is registered.
+    /// </summary>
+    public static IEnemyAI? GetAI(Enemy enemy)
+    {
+        if (_aiByType.TryGetValue(enemy.GetType(), out var ai))
+            return ai;
+        return null;
+    }
+    
+    /// <summary>
+    /// Registers a custom AI implementation for a specific enemy type.
+    /// Used by tests or to add new AI behaviors at runtime.
+    /// </summary>
+    public static void RegisterAI<T>(IEnemyAI ai) where T : Enemy
+    {
+        _aiByType[typeof(T)] = ai;
+    }
+}

--- a/Dungnz.Engine/GoblinAI.cs
+++ b/Dungnz.Engine/GoblinAI.cs
@@ -1,0 +1,29 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+
+/// <summary>
+/// AI implementation for Goblins: cowardly opportunists who flee at low HP
+/// and attack aggressively when the player is weakened.
+/// </summary>
+public class GoblinAI : IEnemyAI
+{
+    public EnemyAction ChooseAction(Enemy self, Player player, CombatContext context)
+    {
+        double selfHPPercent = (double)self.HP / self.MaxHP;
+        
+        // Cowardly: flee when HP drops to or below 25%
+        if (selfHPPercent <= 0.25)
+        {
+            return new EnemyAction(EnemyActionType.Flee);
+        }
+        
+        // Opportunistic: aggressive attack when player is weakened (< 50% HP)
+        if (context.PlayerHPPercent < 0.5)
+        {
+            return new EnemyAction(EnemyActionType.AggressiveAttack, 1.5);
+        }
+        
+        // Default: standard attack
+        return new EnemyAction(EnemyActionType.Attack);
+    }
+}

--- a/Dungnz.Engine/IEnemyAI.cs
+++ b/Dungnz.Engine/IEnemyAI.cs
@@ -4,19 +4,19 @@ namespace Dungnz.Engine;
 
 /// <summary>
 /// Defines the contract for enemy AI decision-making during combat.
-/// Each enemy type can implement its own TakeTurn logic for composable,
+/// Each enemy type can implement its own ChooseAction logic for composable,
 /// testable AI behaviors.
 /// </summary>
 public interface IEnemyAI
 {
     /// <summary>
-    /// Executes the enemy's turn logic: choosing attacks, healing, applying
-    /// status effects, or other combat actions.
+    /// Chooses the enemy's action for this turn based on combat state.
     /// </summary>
     /// <param name="self">The enemy performing the action.</param>
     /// <param name="player">The player being targeted.</param>
     /// <param name="context">Combat context with round number, player HP%, and floor info.</param>
-    void TakeTurn(Enemy self, Player player, CombatContext context);
+    /// <returns>The action the enemy will attempt to perform.</returns>
+    EnemyAction ChooseAction(Enemy self, Player player, CombatContext context);
 }
 
 /// <summary>
@@ -27,3 +27,34 @@ public interface IEnemyAI
 /// <param name="PlayerHPPercent">The player's current HP as a fraction of MaxHP (0.0–1.0).</param>
 /// <param name="CurrentFloor">The dungeon floor the combat is occurring on.</param>
 public record CombatContext(int RoundNumber, double PlayerHPPercent, int CurrentFloor);
+
+/// <summary>
+/// Represents an action that an enemy can perform during combat.
+/// </summary>
+/// <param name="Type">The type of action to perform.</param>
+/// <param name="Modifier">Optional modifier for the action (e.g., damage multiplier, accuracy reduction).</param>
+public record EnemyAction(EnemyActionType Type, double Modifier = 1.0);
+
+/// <summary>
+/// Defines the types of actions an enemy can perform during combat.
+/// </summary>
+public enum EnemyActionType
+{
+    /// <summary>Standard melee attack.</summary>
+    Attack,
+    
+    /// <summary>Aggressive double-damage attack.</summary>
+    AggressiveAttack,
+    
+    /// <summary>Armor-piercing attack that ignores defense.</summary>
+    ArmorPiercingAttack,
+    
+    /// <summary>Special ability that reduces player accuracy.</summary>
+    BoneRattle,
+    
+    /// <summary>Attempt to flee from combat.</summary>
+    Flee,
+    
+    /// <summary>Cower in fear, doing nothing.</summary>
+    Cower
+}

--- a/Dungnz.Engine/SkeletonAI.cs
+++ b/Dungnz.Engine/SkeletonAI.cs
@@ -1,0 +1,22 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+
+/// <summary>
+/// AI implementation for Skeletons: relentless undead warriors with armor-piercing attacks
+/// and bone rattle ability that reduces player accuracy.
+/// </summary>
+public class SkeletonAI : IEnemyAI
+{
+    public EnemyAction ChooseAction(Enemy self, Player player, CombatContext context)
+    {
+        // Bone Rattle: every 3rd turn, reduce player accuracy
+        if (context.RoundNumber % 3 == 0)
+        {
+            return new EnemyAction(EnemyActionType.BoneRattle, 0.10); // 10% accuracy reduction
+        }
+        
+        // Relentless: armor-piercing attack (ignores defense)
+        // Skeletons never flee and always use armor-piercing attacks
+        return new EnemyAction(EnemyActionType.ArmorPiercingAttack);
+    }
+}

--- a/Dungnz.Tests/EnemyAITests.cs
+++ b/Dungnz.Tests/EnemyAITests.cs
@@ -1,5 +1,6 @@
 using Dungnz.Engine;
 using Dungnz.Models;
+using Dungnz.Systems.Enemies;
 using FluentAssertions;
 
 namespace Dungnz.Tests;
@@ -15,5 +16,113 @@ public class EnemyAITests
         ctx.RoundNumber.Should().Be(3);
         ctx.PlayerHPPercent.Should().BeApproximately(0.75, 0.001);
         ctx.CurrentFloor.Should().Be(2);
+    }
+
+    // ── GoblinAI Tests ──────────────────────────────────────────────
+
+    [Fact]
+    public void GoblinAI_LowHP_ChoosesFlee()
+    {
+        var goblin = new Goblin { HP = 5, MaxHP = 20 }; // 25% HP
+        var player = new Player { Name = "Test", HP = 50, MaxHP = 100 };
+        var context = new CombatContext(RoundNumber: 1, PlayerHPPercent: 0.5, CurrentFloor: 1);
+        var ai = new GoblinAI();
+
+        var action = ai.ChooseAction(goblin, player, context);
+
+        action.Type.Should().Be(EnemyActionType.Flee);
+    }
+
+    [Fact]
+    public void GoblinAI_PlayerWeakened_ChoosesAggressiveAttack()
+    {
+        var goblin = new Goblin { HP = 15, MaxHP = 20 }; // 75% HP
+        var player = new Player { Name = "Test", HP = 40, MaxHP = 100 }; // 40% HP
+        var context = new CombatContext(RoundNumber: 1, PlayerHPPercent: 0.4, CurrentFloor: 1);
+        var ai = new GoblinAI();
+
+        var action = ai.ChooseAction(goblin, player, context);
+
+        action.Type.Should().Be(EnemyActionType.AggressiveAttack);
+        action.Modifier.Should().BeApproximately(1.5, 0.001);
+    }
+
+    [Fact]
+    public void GoblinAI_HealthyEnemy_ChoosesStandardAttack()
+    {
+        var goblin = new Goblin { HP = 18, MaxHP = 20 }; // 90% HP
+        var player = new Player { Name = "Test", HP = 80, MaxHP = 100 }; // 80% HP
+        var context = new CombatContext(RoundNumber: 1, PlayerHPPercent: 0.8, CurrentFloor: 1);
+        var ai = new GoblinAI();
+
+        var action = ai.ChooseAction(goblin, player, context);
+
+        action.Type.Should().Be(EnemyActionType.Attack);
+    }
+
+    // ── SkeletonAI Tests ────────────────────────────────────────────
+
+    [Fact]
+    public void SkeletonAI_EveryThirdRound_ChoosesBoneRattle()
+    {
+        var skeleton = new Skeleton { HP = 25, MaxHP = 30 };
+        var player = new Player { Name = "Test", HP = 50, MaxHP = 100 };
+        var context = new CombatContext(RoundNumber: 3, PlayerHPPercent: 0.5, CurrentFloor: 1);
+        var ai = new SkeletonAI();
+
+        var action = ai.ChooseAction(skeleton, player, context);
+
+        action.Type.Should().Be(EnemyActionType.BoneRattle);
+        action.Modifier.Should().BeApproximately(0.10, 0.001);
+    }
+
+    [Fact]
+    public void SkeletonAI_NonThirdRound_ChoosesArmorPiercingAttack()
+    {
+        var skeleton = new Skeleton { HP = 25, MaxHP = 30 };
+        var player = new Player { Name = "Test", HP = 50, MaxHP = 100 };
+        var context = new CombatContext(RoundNumber: 2, PlayerHPPercent: 0.5, CurrentFloor: 1);
+        var ai = new SkeletonAI();
+
+        var action = ai.ChooseAction(skeleton, player, context);
+
+        action.Type.Should().Be(EnemyActionType.ArmorPiercingAttack);
+    }
+
+    [Fact]
+    public void SkeletonAI_LowHP_NeverFlees()
+    {
+        var skeleton = new Skeleton { HP = 3, MaxHP = 30 }; // 10% HP, well below goblin flee threshold
+        var player = new Player { Name = "Test", HP = 50, MaxHP = 100 };
+        var context = new CombatContext(RoundNumber: 1, PlayerHPPercent: 0.5, CurrentFloor: 1);
+        var ai = new SkeletonAI();
+
+        var action = ai.ChooseAction(skeleton, player, context);
+
+        action.Type.Should().Be(EnemyActionType.ArmorPiercingAttack);
+    }
+
+    // ── EnemyAIRegistry Tests ───────────────────────────────────────
+
+    [Fact]
+    public void EnemyAIRegistry_GetGoblinAI_ReturnsGoblinAI()
+    {
+        var goblin = new Goblin();
+
+        var ai = EnemyAIRegistry.GetAI(goblin);
+
+        ai.Should().NotBeNull();
+        ai.Should().BeOfType<GoblinAI>();
+    }
+
+    [Fact]
+    public void EnemyAIRegistry_GetSkeletonAI_ReturnsSkeletonAI()
+    {
+        var skeleton = new Skeleton();
+
+        var ai = EnemyAIRegistry.GetAI(skeleton);
+
+        ai.Should().NotBeNull();
+        ai.Should().BeOfType<SkeletonAI>();
     }
 }


### PR DESCRIPTION
## Summary
Defines IEnemyAI interface and implements two distinct combat AI behaviors: cowardly/opportunistic Goblins and relentless Skeletons.

## Changes
- IEnemyAI interface with ChooseAction method
- GoblinAI: flee at low HP, aggressive when player is weak
- SkeletonAI: armor-piercing attacks, bone rattle ability, no flee
- Enemy types wired to their AI implementations
- 8 new tests covering both AI implementations

Closes #1209