### PR TITLE
feat: room-state-aware narration pools (#1207)

### DIFF
--- a/Dungnz.Systems/NarrationService.cs
+++ b/Dungnz.Systems/NarrationService.cs
@@ -1,6 +1,19 @@
 namespace Dungnz.Systems;
 
 /// <summary>
+/// Room state identifiers for context-aware narration.
+/// </summary>
+public enum RoomNarrationState
+{
+    FirstVisit,
+    ActiveEnemies,
+    Cleared,
+    Merchant,
+    Shrine,
+    Boss
+}
+
+/// <summary>
 /// Central service for retrieving varied narrative text from weighted pools.
 /// </summary>
 public class NarrationService
@@ -44,4 +57,85 @@ public class NarrationService
 
     /// <summary>Returns true with the given probability (0.0–1.0).</summary>
     public bool Chance(double probability) => _rng.NextDouble() < probability;
+
+    /// <summary>Returns a random room entry narration line based on the current room state.</summary>
+    public string GetRoomEntryNarration(RoomNarrationState state)
+    {
+        return state switch
+        {
+            RoomNarrationState.FirstVisit => Pick(_firstVisitPool),
+            RoomNarrationState.ActiveEnemies => Pick(_activeEnemiesPool),
+            RoomNarrationState.Cleared => Pick(_clearedPool),
+            RoomNarrationState.Merchant => Pick(_merchantPool),
+            RoomNarrationState.Shrine => Pick(_shrinePool),
+            RoomNarrationState.Boss => Pick(_bossPool),
+            _ => string.Empty
+        };
+    }
+
+    private static readonly string[] _firstVisitPool = new[]
+    {
+        "You step into shadow-drenched stone. The air tastes of rust and old death.",
+        "Torch-flicker reveals scratches on the walls—tally marks, or warnings.",
+        "Your footsteps echo. Something listens in the dark.",
+        "The corridor yawns ahead. Every dungeon begins with a single step—and every step could be your last.",
+        "Cold stone beneath your boots. This place remembers every soul who fell here.",
+        "You push deeper. The dungeon doesn't care if you're ready.",
+        "Dust swirls in the dim light. No one's walked this path in years—maybe for good reason."
+    };
+
+    private static readonly string[] _activeEnemiesPool = new[]
+    {
+        "Eyes gleam from the shadows. They've been waiting.",
+        "Movement—sharp, hungry. Time to earn your passage.",
+        "Something shifts in the dark. It's seen you. It's not running.",
+        "You hear breath that isn't yours. Steel meets flesh in three… two…",
+        "Claws scrape stone. They smell blood—yours, if you're not careful.",
+        "The chamber erupts. You're not the hunter here anymore.",
+        "Snarls echo off the walls. No negotiation. Only violence."
+    };
+
+    private static readonly string[] _clearedPool = new[]
+    {
+        "Silence settles over broken bodies. You've earned a breath.",
+        "Blood pools on ancient stone. The room is yours—for now.",
+        "You step over the dead. The dungeon will remember this.",
+        "Victory tastes like iron and ash. Keep moving.",
+        "The last enemy falls. Enjoy the quiet while it lasts.",
+        "Corpses litter the floor. You're still standing. That's what matters.",
+        "The fight is done. Loot fast, leave faster."
+    };
+
+    private static readonly string[] _merchantPool = new[]
+    {
+        "A campfire flickers. Someone's set up shop in hell itself.",
+        "The merchant grins through crooked teeth. 'Coin spends the same, even down here.'",
+        "Trade goods glint in the firelight. Survival has a price.",
+        "You spot a familiar face—or what passes for one this deep. Time to haggle.",
+        "A voice calls out: 'You look like you need supplies. Lucky me.'",
+        "The merchant's wares sprawl across a worn blanket. Business as usual in the abyss.",
+        "Somehow, commerce thrives where heroes die. Capitalism never sleeps."
+    };
+
+    private static readonly string[] _shrinePool = new[]
+    {
+        "Ancient power hums in the air. Something older than stone dwells here.",
+        "A shrine—cracked, forgotten, but still breathing with faint divine light.",
+        "You feel the weight of old gods. They offer gifts, but nothing is free.",
+        "Sacred ground, soaked in centuries of desperate prayers. Will yours be answered?",
+        "The shrine pulses softly. Miracles and curses wear the same face down here.",
+        "Candles burn with no wick. This place defies the dungeon's hunger.",
+        "You stand before the altar. Blessing or bargain—what's the difference anymore?"
+    };
+
+    private static readonly string[] _bossPool = new[]
+    {
+        "The chamber opens wide. Something massive stirs in the depths.",
+        "Your heart pounds. This is it—the monster at the end of the story.",
+        "The air itself recoils. You've found what the dungeon's been hiding.",
+        "A roar shakes dust from the ceiling. No running now.",
+        "You step into the arena. Legends are written in blood—yours or theirs.",
+        "The boss rises. Every fight before this was a warm-up.",
+        "This is the moment. Win and ascend. Lose and feed the dark."
+    };
 }

--- a/Dungnz.Tests/NarrationServiceTests.cs
+++ b/Dungnz.Tests/NarrationServiceTests.cs
@@ -51,4 +51,30 @@ public class NarrationServiceTests
         var svc = new NarrationService();
         Assert.True(svc.Chance(1.0));
     }
+
+    [Theory]
+    [InlineData(RoomNarrationState.FirstVisit)]
+    [InlineData(RoomNarrationState.ActiveEnemies)]
+    [InlineData(RoomNarrationState.Cleared)]
+    [InlineData(RoomNarrationState.Merchant)]
+    [InlineData(RoomNarrationState.Shrine)]
+    [InlineData(RoomNarrationState.Boss)]
+    public void GetRoomEntryNarration_ReturnsNonEmptyString(RoomNarrationState state)
+    {
+        var svc = new NarrationService();
+        var result = svc.GetRoomEntryNarration(state);
+        Assert.False(string.IsNullOrEmpty(result));
+    }
+
+    [Fact]
+    public void GetRoomEntryNarration_ReturnsDifferentLinesOnMultipleCalls()
+    {
+        var svc = new NarrationService();
+        var results = new HashSet<string>();
+        for (int i = 0; i < 20; i++)
+        {
+            results.Add(svc.GetRoomEntryNarration(RoomNarrationState.FirstVisit));
+        }
+        Assert.True(results.Count > 1, "Expected variety in narration picks");
+    }
 }


### PR DESCRIPTION
## Summary
Adds distinct narration pools for each room state with atmospheric dungeon-crawler flavor text.

## Changes
- RoomNarrationState enum (FirstVisit, ActiveEnemies, Cleared, Merchant, Shrine, Boss)
- NarrationService extended with GetRoomEntryNarration() method
- 7 gritty Dark Souls-meets-MCU lines per room state (second-person present tense)
- Comprehensive unit tests for all narration states

## Testing
- ✅ All 1,741 tests passing
- ✅ New tests verify non-empty narration for each state
- ✅ Variety test ensures random selection works

Closes #1207