### PR TITLE
fix(engine): register all 29 enemy AI types + CommandHandlerBase

### DIFF
--- a/Dungnz.Engine/Commands/CommandHandlerBase.cs
+++ b/Dungnz.Engine/Commands/CommandHandlerBase.cs
@@ -1,0 +1,38 @@
+namespace Dungnz.Engine.Commands;
+
+/// <summary>
+/// Base class for command handlers that provides common functionality including
+/// automatic room view refresh after execution. Subclasses implement HandleCore
+/// and optionally override ShouldRefreshRoom to control the refresh behavior.
+/// </summary>
+public abstract class CommandHandlerBase : ICommandHandler
+{
+    /// <summary>
+    /// Executes the command using template method pattern:
+    /// calls HandleCore, then conditionally refreshes the room view.
+    /// </summary>
+    public void Handle(string argument, CommandContext context)
+    {
+        HandleCore(argument, context);
+        
+        if (ShouldRefreshRoom())
+        {
+            context.Display.ShowRoom(context.CurrentRoom);
+        }
+    }
+
+    /// <summary>
+    /// Core command logic to be implemented by subclasses.
+    /// </summary>
+    /// <param name="argument">The argument string provided with the command.</param>
+    /// <param name="context">The command execution context.</param>
+    protected abstract void HandleCore(string argument, CommandContext context);
+
+    /// <summary>
+    /// Determines whether ShowRoom should be called after HandleCore completes.
+    /// Default is true. Override to return false for commands like SAVE, LEADERBOARD,
+    /// or other informational commands that don't require a room refresh.
+    /// </summary>
+    /// <returns>True if ShowRoom should be called, false otherwise.</returns>
+    protected virtual bool ShouldRefreshRoom() => true;
+}

--- a/Dungnz.Engine/Commands/HelpCommandHandler.cs
+++ b/Dungnz.Engine/Commands/HelpCommandHandler.cs
@@ -1,10 +1,9 @@
 namespace Dungnz.Engine.Commands;
 
-internal sealed class HelpCommandHandler : ICommandHandler
+internal sealed class HelpCommandHandler : CommandHandlerBase
 {
-    public void Handle(string argument, CommandContext context)
+    protected override void HandleCore(string argument, CommandContext context)
     {
         context.Display.ShowHelp();
-        context.Display.ShowRoom(context.CurrentRoom);
     }
 }

--- a/Dungnz.Engine/Commands/MapCommandHandler.cs
+++ b/Dungnz.Engine/Commands/MapCommandHandler.cs
@@ -1,10 +1,9 @@
 namespace Dungnz.Engine.Commands;
 
-internal sealed class MapCommandHandler : ICommandHandler
+internal sealed class MapCommandHandler : CommandHandlerBase
 {
-    public void Handle(string argument, CommandContext context)
+    protected override void HandleCore(string argument, CommandContext context)
     {
         context.Display.ShowMap(context.CurrentRoom, context.CurrentFloor);
-        context.Display.ShowRoom(context.CurrentRoom);
     }
 }

--- a/Dungnz.Engine/Commands/StatsCommandHandler.cs
+++ b/Dungnz.Engine/Commands/StatsCommandHandler.cs
@@ -1,13 +1,12 @@
 namespace Dungnz.Engine.Commands;
 
-internal sealed class StatsCommandHandler : ICommandHandler
+internal sealed class StatsCommandHandler : CommandHandlerBase
 {
     private const int FinalFloor = DungeonGenerator.FinalFloor;
 
-    public void Handle(string argument, CommandContext context)
+    protected override void HandleCore(string argument, CommandContext context)
     {
         context.Display.ShowPlayerStats(context.Player);
         context.Display.ShowMessage($"Floor: {context.CurrentFloor} / {FinalFloor}");
-        context.Display.ShowRoom(context.CurrentRoom);
     }
 }

--- a/Dungnz.Engine/DefaultEnemyAI.cs
+++ b/Dungnz.Engine/DefaultEnemyAI.cs
@@ -1,0 +1,15 @@
+namespace Dungnz.Engine;
+using Dungnz.Models;
+
+/// <summary>
+/// Default AI implementation for enemies without specialized behaviors.
+/// Uses a simple attack strategy with no special tactics.
+/// </summary>
+public class DefaultEnemyAI : IEnemyAI
+{
+    public EnemyAction ChooseAction(Enemy self, Player player, CombatContext context)
+    {
+        // Simple aggressive behavior: standard attack every turn
+        return new EnemyAction(EnemyActionType.Attack);
+    }
+}

--- a/Dungnz.Engine/EnemyAIRegistry.cs
+++ b/Dungnz.Engine/EnemyAIRegistry.cs
@@ -8,10 +8,55 @@ using Dungnz.Systems.Enemies;
 /// </summary>
 public static class EnemyAIRegistry
 {
+    private static readonly DefaultEnemyAI _defaultAI = new();
+    private static readonly GoblinAI _goblinAI = new();
+    private static readonly SkeletonAI _skeletonAI = new();
+    
     private static readonly Dictionary<Type, IEnemyAI> _aiByType = new()
     {
-        { typeof(Goblin), new GoblinAI() },
-        { typeof(Skeleton), new SkeletonAI() }
+        // Specialized AI implementations
+        { typeof(Goblin), _goblinAI },
+        { typeof(Skeleton), _skeletonAI },
+        
+        // Regular enemies - using default AI
+        { typeof(BladeDancer), _defaultAI },
+        { typeof(BloodHound), _defaultAI },
+        { typeof(BoneArcher), _defaultAI },
+        { typeof(CarrionCrawler), _defaultAI },
+        { typeof(ChaosKnight), _defaultAI },
+        { typeof(CryptPriest), _defaultAI },
+        { typeof(CursedZombie), _defaultAI },
+        { typeof(DarkKnight), _defaultAI },
+        { typeof(DarkSorcerer), _defaultAI },
+        { typeof(FrostWyvern), _defaultAI },
+        { typeof(GiantRat), _defaultAI },
+        { typeof(GoblinShaman), _defaultAI },
+        { typeof(IronGuard), _defaultAI },
+        { typeof(ManaLeech), _defaultAI },
+        { typeof(Mimic), _defaultAI },
+        { typeof(NightStalker), _defaultAI },
+        { typeof(PlagueBear), _defaultAI },
+        { typeof(ShadowImp), _defaultAI },
+        { typeof(ShieldBreaker), _defaultAI },
+        { typeof(SiegeOgre), _defaultAI },
+        { typeof(StoneGolem), _defaultAI },
+        { typeof(Troll), _defaultAI },
+        { typeof(VampireLord), _defaultAI },
+        { typeof(Wraith), _defaultAI },
+        
+        // Boss enemies - using default AI
+        { typeof(GoblinWarchief), _defaultAI },
+        { typeof(PlagueHoundAlpha), _defaultAI },
+        { typeof(IronSentinel), _defaultAI },
+        { typeof(BoneArchon), _defaultAI },
+        { typeof(CrimsonVampire), _defaultAI },
+        { typeof(LichKing), _defaultAI },
+        { typeof(StoneTitan), _defaultAI },
+        { typeof(ShadowWraith), _defaultAI },
+        { typeof(VampireBoss), _defaultAI },
+        { typeof(ArchlichSovereign), _defaultAI },
+        { typeof(AbyssalLeviathan), _defaultAI },
+        { typeof(InfernalDragon), _defaultAI }
     };
     
     /// <summary>


### PR DESCRIPTION
Closes #1225
Closes #1226

## Changes
- Registered all 38 enemy types in EnemyAIRegistry (was only 2)
  - 2 with specialized AI (Goblin, Skeleton)
  - 24 regular enemies with DefaultEnemyAI
  - 12 boss variants with DefaultEnemyAI
- Created DefaultEnemyAI for enemies without specialized behaviors
- Created CommandHandlerBase with template method pattern for ShowRoom enforcement
- Migrated 3 handlers as proof of concept: Stats, Map, Help

## Notes
Full migration of existing handlers to CommandHandlerBase is a follow-up task.