### PR TITLE
fix: repair 5 P1/P2 bugs — SetBonus stat wiring + stryker CI

### DIFF
--- a/.github/workflows/squad-stryker.yml
+++ b/.github/workflows/squad-stryker.yml
@@ -24,7 +24,7 @@ jobs:
         run: dotnet restore
 
       - name: Install Stryker.NET
-        run: dotnet tool install --global dotnet-stryker
+        run: dotnet tool restore
 
       - name: Run Stryker mutation tests
         run: |

--- a/Dungnz.Engine/AttackResolver.cs
+++ b/Dungnz.Engine/AttackResolver.cs
@@ -123,6 +123,7 @@ public class AttackResolver : IAttackResolver
         else
         {
             var playerEffAtk = player.Attack + _statusEffects.GetStatModifier(player, "Attack");
+            playerEffAtk += SetBonusManager.GetActiveBonuses(player).Sum(b => b.AttackBonus);
             var effectiveDef = Math.Max(0, enemy.Defense - player.EnemyDefReduction);
             var playerDmg = Math.Max(1, playerEffAtk - effectiveDef);
 
@@ -327,7 +328,8 @@ public class AttackResolver : IAttackResolver
         {
             float bonus = (player.EquippedWeapon?.CritChance ?? 0)
                         + (player.EquippedAccessory?.CritChance ?? 0)
-                        + player.AllEquippedArmor.Sum(a => a.CritChance);
+                        + player.AllEquippedArmor.Sum(a => a.CritChance)
+                        + SetBonusManager.GetActiveBonuses(player).Sum(b => b.CritChanceBonus);
             baseCrit += bonus;
         }
         return _rng.NextDouble() < baseCrit;

--- a/Dungnz.Systems/SetBonusManager.cs
+++ b/Dungnz.Systems/SetBonusManager.cs
@@ -118,7 +118,7 @@ public static class SetBonusManager
         },
         new SetBonus
         {
-            SetId = "shadowstalker", PiecesRequired = 4,
+            SetId = "shadowstep-set", PiecesRequired = 4,
             Description = "Shadowstep 4-piece: every hit guarantees Bleed on the target",
             SetBonusAppliesBleed = true
         },
@@ -227,6 +227,8 @@ public static class SetBonusManager
         player.SetBonusMaxHP    = totalHP;
         player.SetBonusMaxMana  = totalMana;
         player.SetBonusDodge    = totalDodge;
+        player.MaxHP   += totalHP;
+        player.MaxMana += totalMana;
 
         // Wire 4-piece set bonus flags onto the player so combat systems can read them.
         player.DamageReflectPercent = active.Sum(b => b.DamageReflectPercent);


### PR DESCRIPTION
Closes #1229
Closes #1240
Closes #1242
Closes #1253
Closes #1254

## Changes

### SetBonusManager.cs
- **#1240** Shadowstalker 4-piece SetId 'shadowstalker' → 'shadowstep-set' (was broken — wrong ID never matched any equipped items)
- **#1242** Apply MaxHP/MaxMana bonuses to `player.MaxHP` and `player.MaxMana` (fields were computed but never applied)

### AttackResolver.cs
- **#1254** Include `SetBonus.AttackBonus` in player effective attack damage calculation
- **#1253** Include `SetBonus.CritChanceBonus` in `RollCrit()` bonus sum

### squad-stryker.yml
- **#1229** Replace `dotnet tool install --global dotnet-stryker` with `dotnet tool restore` to honour `.config/dotnet-tools.json` manifest (pinned v4.12.0)

## Testing
- ✅ Build: 0 warnings, 0 errors  
- ✅ 1759 tests passing