### PR TITLE
docs(ai-team): combat improvements wave 1 session log

### DIFF
--- a/.ai-team/agents/barton/history.md
+++ b/.ai-team/agents/barton/history.md
@@ -1928,3 +1928,33 @@ Never call `AnsiConsole.Prompt()` while `Live.Start()` callback is running. The 
 **PR:** https://github.com/AnthonyMFuller/Dungnz/pull/1266
 **Build:** ✅ Success (0 errors)
 **Closes:** #1265
+
+### 2026-03-08 — Added Cooldown Visibility to Combat HUD (#1268)
+
+**Context:** Ability cooldowns were tracked and enforced correctly, but completely invisible during normal combat. Players couldn't see which abilities were on cooldown or when they'd come back, leading to attack spam rather than tactical ability usage.
+
+**Solution:**
+- Added `UpdateCooldownDisplay(IReadOnlyList<(string name, int turnsRemaining)> cooldowns)` as a **default interface method** on `IDisplayService` (no-op default) — zero impact on test stubs
+- `SpectreLayoutDisplayService` overrides it: caches the list, re-renders the Stats panel to show a `CD:` line under the MP bar
+- Format: `CD: ShieldBash:2t  BattleCry:✅  Fortify:✅` — only abilities with a cooldown mechanic (CooldownTurns > 0) are shown; `✅` = ready, `Nt` = N turns remaining
+- Cleared when `ShowRoom()` is called (player leaves combat, section disappears)
+- `CombatEngine` calls this after `TickCooldowns()` each turn
+- Also added **toast notifications** via `ShowCombatMessage` when an ability transitions from on-cooldown → ready: `✅ Shield Bash is ready!`
+
+**Architecture note:** Used a default interface method rather than adding to all 5 `IDisplayService` implementations. .NET 10 fully supports this pattern.
+
+**Files Modified:**
+- `Dungnz.Models/IDisplayService.cs` — added `UpdateCooldownDisplay()` default method
+- `Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs` — `_cachedCooldowns` field, `UpdateCooldownDisplay()` override, cooldown line in `RenderStatsPanel`, clear in `ShowRoom`
+- `Dungnz.Engine/CombatEngine.cs` — pre-tick capture, toasts, `UpdateCooldownDisplay()` call
+
+**PR:** https://github.com/AnthonyMFuller/Dungnz/pull/1276
+**Build:** ✅ Success (0 errors, 0 warnings)
+**Closes:** #1268
+
+## Learnings
+
+- **Default interface methods are the right tool** when adding display-only hooks to `IDisplayService` — avoids touching all 5 implementations (FakeDisplayService, TestDisplayService, ConsoleDisplayService, SpectreDisplayService, SpectreLayoutDisplayService)
+- **`_cachedCooldowns = []`** (C# 12 collection expression) works cleanly for empty list initialization of `IReadOnlyList<T>` fields in .NET 10
+- **Stats panel vs Content panel split:** `ShowCombatStatus` only updates the Content panel (the narrative); `RenderStatsPanel` owns the top-right Stats panel. HUD additions belong in `RenderStatsPanel`, not `ShowCombatStatus`
+- **Pre-tick snapshot pattern for toast detection:** capture `GetCooldown() > 0` state before `TickCooldowns()`, compare after — any that went to 0 fire a toast

--- a/.ai-team/agents/fury/history.md
+++ b/.ai-team/agents/fury/history.md
@@ -96,3 +96,43 @@
 ---
 
 📌 **Team update (2026-03-01):** Retro action items adopted by team — content review in PR flow: Fury must be CC'd on any PR that touches player-facing strings (command names, UI labels, display text) for lightweight review pass before merge. — decided by Coulson (Retrospective)
+
+---
+
+### 2026-03-08 — Enemy Critical Hit Reactions (#1269)
+
+**PR:** #1275 — `feat(content): add enemy crit reaction narration`  
+**Branch:** `squad/1269-enemy-crit-reactions`  
+**Files Modified:** `Dungnz.Systems/EnemyNarration.cs`, `Dungnz.Systems/NarrationService.cs`, `Dungnz.Engine/CombatEngine.cs`
+
+**Requirement:**
+- When enemies land critical hits, display enemy-specific personality-driven reactions
+- Previous behavior: generic "💥 Critical hit!" message (silent, mechanical)
+- Goal: Make crits feel threatening and dramatic with flavor matching each enemy archetype
+
+**Solution:**
+- Added `_critReactions` dictionary to EnemyNarration.cs with 3-4 unique lines per enemy
+- All 31 enemy types covered (93 total lines)
+- Added `GetEnemyCritReaction(string enemyName)` public method to NarrationService
+- Integrated into CombatEngine.PerformEnemyTurn() at line 796-810
+- Falls back to generic message if no custom reaction defined
+
+**Content Quality:**
+- Each reaction matches enemy archetype:
+  - Goblins: gleeful, cocky ("HEHEHE! Didn't see that coming, did ya?!")
+  - Dark Knights: arrogant, threatening ("Pathetic. I've cleaved kingdoms apart.")
+  - Wraiths: unsettling, ethereal ("Your life force splinters beneath my touch!")
+  - Infernal Dragons: dramatic, primal ("FLAMES CONSUME! Ash is all you'll leave behind!")
+- Language matches MCU-style dramatic tone — stakes feel real
+- Variation in length (short punchy + slightly longer dramatic lines)
+
+**Testing:**
+- ✅ All 1,777 tests passing
+- ✅ Build succeeds with no warnings or errors
+- ✅ Code follows existing narration pool patterns (static arrays, StringComparer.OrdinalIgnoreCase)
+
+**Key Learning:**
+- EnemyNarration static dictionary pattern scales cleanly for 30+ enemies
+- NarrationService.Pick(pool) method handles random selection uniformly
+- CombatEngine integration point identified and implemented (enemy crit roll + display message)
+- ColorCodes.Colorize() with BrightRed + Bold makes crit reactions visually dramatic

--- a/.ai-team/agents/romanoff/history.md
+++ b/.ai-team/agents/romanoff/history.md
@@ -1608,3 +1608,39 @@ When queues are configured, `ShowSellMenuAndSelect`, `ShowConfirmMenu`, and `Sho
 - ❌ PR #1255 — Restore deleted files, document set bonus changes
 - ❌ PR #1259 — Add missing MaxHP/MaxMana and CritChanceBonus fixes
 - ❌ PR #1261 — Restore deleted files, remove unrelated changes, improve test depth
+
+### 2026-03-08 — Combat Baseline Tests (#1273)
+
+**PR:** #1277 — `test: add 11 combat baseline tests`
+**Branch:** `squad/1273-combat-baseline-tests`
+**File Created:** `Dungnz.Tests/CombatBaselineTests.cs`
+
+**Tests written: 11 methods, 14 test cases (Theory × 4 classes)**
+- All 14 test cases pass. 0 skipped.
+- Full suite: 1791 tests, 0 failures.
+
+**Key findings from reading the combat code:**
+
+1. **Turn loop order** (CombatEngine.cs ~line 185–400): `ProcessTurnStart(player/enemy)` → passive effects → periodic damage → player death check → enemy death check → mana regen → cooldown tick → boss phase check → player acts → enemy acts. Status effects fire BEFORE player or enemy get their turn. Enemy death from DoT is caught at the START of the turn (player never attacks that turn).
+
+2. **Boss phases use `FiredPhases` HashSet as the deduplication guard** (DungeonBoss.cs + CombatEngine.cs ~line 244–254). Phase fires when `hp/maxHP <= threshold && !FiredPhases.Contains(abilityName)`. Fires every turn-start check until the name is added. This is the correct hook for the "exactly once" assertion.
+
+3. **Cooldown lifecycle** (AbilityManager.cs): `PutOnCooldown(type, n)` sets `_cooldowns[type] = n`. `TickCooldowns()` decrements. `IsOnCooldown(type)` checks `_cooldowns[type] > 0`. After exactly n ticks: 0, IsOnCooldown = false. Verified with Fortify (3-turn cooldown).
+
+4. **Status effect ticking** (StatusEffectManager.cs): `ProcessTurnStart` applies damage, then decrements `RemainingTurns`, then removes if `<= 0`. Duration=2 means: tick 1 → stays (1 remaining), tick 2 → removed (0). Both Burn (fallback=8) and Poison (fallback=3) tick on the same ProcessTurnStart call — no ordering issue between them.
+
+5. **Narration hooks**: Combat intro calls `_display.ShowCombat(...)` once before the turn loop starts. `ShowDeathNarration` also calls `ShowCombat`. For a 1-turn combat: 2 `"combat:"` entries in AllOutput (intro + death). Intro always precedes first `"status:"` entry.
+
+6. **Ability damage is NOT guarded by class restriction in `UseAbility`** — only level, cooldown, and mana are checked. Class restriction is only enforced in `GetUnlockedAbilities` / `GetAvailableAbilities`. Direct `UseAbility` calls bypass the class check. Test calls it directly for clean isolation.
+
+7. **Existing bugs confirmed from history doc but not blocking tests**:
+   - Boss loot scaling broken (HandleLootAndXP ignores isBossRoom/floor)
+   - Enemy HP can go negative in some paths (basic Enemy_Stub uses `Math.Max(0, ...)`)
+   - SoulHarvest dual implementation risk
+
+**Test patterns that work well:**
+- Injecting `StatusEffectManager` with pre-applied effects via constructor injection — works because effects are keyed by object reference, and `player.ActiveEffects` restoration only applies to the player, not enemy.
+- `AllOutput.Where(x => x.StartsWith("combat:"))` to spy on `ShowCombat` calls without checking string content (NarrationSpy pattern).
+- `DungeonBoss.FiredPhases.Contains("abilityName")` as the authoritative "fired once" assertion — avoids message string checks.
+- `new DungeonBoss()` then set HP/MaxHP/Defense directly for boss tests — public parameterless equivalent constructor works; `Phases.Add(new BossPhase(...))` modifies the list correctly.
+- Avoid `player.HP < 100` when player starts with hp > 100 — use `player.HP < player.MaxHP` instead.

--- a/.ai-team/decisions.md
+++ b/.ai-team/decisions.md
@@ -3555,3 +3555,180 @@ Added three test suites to close high-priority testing gaps:
 - Consider CommandHandlerShowRoomTests as template for future command handler tests
 - Save/load tests should always verify AI-specific state (boss mechanics, pack counts, etc.)
 - Integration tests should cover full user workflows, not just isolated units
+
+---
+
+## 2026-03-08: Combat Improvement Plan — Phase Overview
+
+**Decided by:** Coulson, Barton, Fury, Romanoff  
+**Date:** 2026-03-08  
+**Status:** Approved, implementation started
+
+### Three-Phase Approach
+
+1. **P0 Quick Wins (2-3 sessions)**
+   - Cooldown HUD visibility fix
+   - Enemy crit reaction narration
+   - Pure display changes, zero logic risk
+
+2. **P1 Core (5-6 sessions)**
+   - Enemy telegraph system (reuses boss patterns)
+   - Mid-combat banter
+   - Phase-aware narration
+
+3. **P2 Stretch (3-4 sessions)**
+   - Momentum resource system
+   - Requires CombatEngine state machine expansion (MEDIUM risk)
+
+### Key Finding
+
+Cooldowns already work correctly. The problem is visibility — they're tracked but never shown on the main HUD. Players can't see ability cooldown status without opening the menu, so they default to attack spam.
+
+### Critical Dependency
+
+**No combat PRs merge until Romanoff's 11-test baseline exists (PR #1277).**
+- Baseline validates turn loop phase ordering
+- Cooldown mechanics (block + tick)
+- Ability damage quantification
+- Multi-effect status interactions
+- Boss phase transitions
+
+---
+
+## 2026-03-08: Cooldown HUD Display Pattern — Default Interface Methods
+
+**Author:** Barton  
+**Issue:** #1268  
+**PR:** #1276  
+**Date:** 2026-03-08
+
+### Decision
+
+When adding display-only hooks to `IDisplayService`, use default interface methods rather than abstract members requiring all 5 implementations to add stubs.
+
+### Rationale
+
+- Only `SpectreLayoutDisplayService` needs cooldown rendering
+- Other 4 implementations (Spectre legacy, Console, FakeDisplay, TestDisplay) have nothing to render
+- Default no-op method reduces implementation surface from 5 files to 1
+- Pattern is language-standard in C# 13 / .NET 10
+
+### Application
+
+Add `UpdateCooldownDisplay(IReadOnlyList<(string name, int turnsRemaining)> cooldowns)` as default method. Test stubs inherit no-op automatically.
+
+### Future Guidance
+
+All display-only features specific to Spectre Live renderer should follow this pattern instead of polluting `IDisplayService` with stubs.
+
+---
+
+## 2026-03-08: Combat Baseline Testing Patterns — Romanoff QA Standards
+
+**Author:** Romanoff  
+**Issue:** #1273  
+**PR:** #1277  
+**Date:** 2026-03-08
+
+### Pattern 1: Narration Tests
+
+Assert via message counts + ordering, never string content.
+
+```
+AllOutput.Count(x => x.StartsWith("combat:")).Should().Be(3);
+AllOutput.IndexOf("combat:crit").Should().BeLessThan(AllOutput.IndexOf("combat:damage"));
+```
+
+**Rationale:** Tests remain resilient when narration copy is updated. Message ordering validates narrative sequencing.
+
+### Pattern 2: Boss Phase Deduplication
+
+Assert via `FiredPhases` HashSet, not display message counts.
+
+```
+boss.FiredPhases.Should().Contain("abilityName");
+```
+
+**Rationale:** The HashSet is the actual deduplication guard in production code. Avoids coupling tests to display strings.
+
+### Pattern 3: Ability Isolation Tests
+
+Call `AbilityManager.UseAbility()` directly, not full `RunCombat()`.
+
+**Rationale:** Ability pipeline is isolated from combat loop, input reader, and other noise. Restriction check lives in `GetAvailableAbilities()`, not `UseAbility()`, so direct calls are acceptable.
+
+### Pattern 4: Pre-Combat Status Setup
+
+Construct `StatusEffectManager`, call `Apply()` on enemy, inject via engine constructor:
+
+```
+var sem = new StatusEffectManager();
+sem.Apply(enemy, new PoisonEffect(), 3);
+new CombatEngine(..., statusEffects: sem)
+```
+
+**Rationale:** Engine does NOT clear enemy effects on start (only player.ActiveEffects). This is clean pre-combat status setup.
+
+### Pattern 5: Damage Assertion Sentinel
+
+Use `player.HP.Should().BeLessThan(player.MaxHP)`, not hardcoded HP values.
+
+**Rationale:** If `MakePlayer()` evolves, assertion remains valid. Never hardcode starting HP.
+
+---
+
+## 2026-03-08: Enemy Crit Reactions — Personality-Driven Content
+
+**Author:** Fury  
+**Issue:** #1269  
+**PR:** #1275  
+**Date:** 2026-03-08
+
+### Coverage
+
+All 31 enemy types have personality-driven crit reactions:
+- 93 total lines of content (3-4 lines per enemy)
+- Static `_critReactions` dictionary in EnemyNarration.cs
+- Keys are case-insensitive via `StringComparer.OrdinalIgnoreCase`
+
+### Personality Archetypes
+
+| Enemy Type | Voice | Sample |
+|---|---|---|
+| Goblin | Gleeful, cocky | "HEHEHE! Didn't see that coming?" |
+| Skeleton | Cold, mocking | "Foolish mortal. Your bones will join mine." |
+| Dark Knight | Arrogant, threatening | "Pathetic. I've cleaved kingdoms." |
+| Wraith | Unsettling, ethereal | "Your life force splinters." |
+| Infernal Dragon | Dramatic, primal | "FLAMES CONSUME! Ash is all you'll leave!" |
+| Vampire Lord | Seductive, predatory | "Exquisite! Your blood sings to me." |
+| Mimic | Deceptive, hungry | "You thought it treasure. It WAS your doom!" |
+| Iron Guard | Disciplined, methodical | "Steel discipline meets your reckless thrashing." |
+
+### Tone Principles
+
+✅ **DO:**
+- Match MCU-style dramatic language
+- Varied sentence structure (short + long)
+- Reference enemy lore/mechanics
+- Make threats feel earned
+
+❌ **DON'T:**
+- Cartoonish evil or slapstick
+- Generic villain monologue
+- Break fourth wall or modern slang
+- Reference player class/stats
+
+### Integration
+
+Added hook in `CombatEngine.PerformEnemyTurn()` at line 796-810:
+1. Roll crit chance
+2. If critical: fetch custom reaction
+3. Display reaction (BrightRed + Bold) OR fallback to "💥 Critical hit!"
+4. Apply damage multiplier
+
+### Future Work
+
+- Boss crit reactions (BossNarration has parallel system)
+- Player reactions to enemy crits ("You barely survived that!")
+- Crit magnitude tiers if damage multipliers expand
+

--- a/.ai-team/log/2026-03-08-combat-design-planning.md
+++ b/.ai-team/log/2026-03-08-combat-design-planning.md
@@ -1,0 +1,121 @@
+# Combat Design Planning Session — 2026-03-08
+**Facilitator:** Coulson  
+**Participants:** Barton (Systems), Fury (Content), Romanoff (QA)  
+**Requested by:** Anthony
+
+## Current State Assessment
+
+Anthony requested combat improvements to address repetitiveness, specifically mentioning:
+- Enemy encounter dialog (banter, variety)
+- Ability cooldowns
+- Anything that makes combat more engaging
+
+### What We Have
+- **Cooldowns already work** — AbilityManager tracks cooldowns correctly, decrements them per turn, blocks usage on cooldown
+- **Bookend narration exists** — EnemyNarration has 3 intros + 3 deaths per enemy (9 types), BossNarration has multi-line intros/deaths/phases (12 bosses)
+- **Combat foundation solid** — 30 class-specific abilities across 6 classes, status effects, enemy special mechanics, boss phases
+
+### The Core Problem: Turn Homogeneity
+Every turn presents identical choices: Attack / Ability / Item / Flee. No reactive decisions, no read-ahead, no momentum, no mid-combat personality. Cooldowns exist but are **invisible on the main HUD** — players don't know when abilities return until they check the menu.
+
+## Decisions
+
+### P0 — Quick Wins (High Impact, Low Risk)
+
+#### 1. Make Cooldowns Visible
+**Owner:** Barton  
+**What:** Add cooldown display to main combat HUD showing ability status with turn counts. Add toast notifications when key abilities come off cooldown.  
+**Why:** Cooldowns already work but are invisible — players default to attack spam because they can't see when abilities are ready. Pure display change, zero logic risk.  
+**Size:** S (40 lines, display-only)
+
+#### 2. Enemy Crit Reactions
+**Owner:** Fury  
+**What:** Add 3 enemy-specific lines per enemy type (9×3 = 27 lines) that fire when enemy lands a critical hit. Make enemy crits visible and threatening.  
+**Why:** Biggest immersion gap — player crits have rich output, enemy crits are silent. Breaks combat rhythm in a consequential way.  
+**Size:** S (content + 1 hook in AttackResolver)
+
+### P1 — Core Improvements (Medium Complexity)
+
+#### 3. Enemy Intent Telegraph System
+**Owner:** Barton + Fury  
+**What:** Display one-line warning before special enemy actions fire (e.g., "The Skeleton's ribcage glows — it's preparing Bone Rattle"). Extend boss telegraph pattern to all enemies. Adds 3 telegraph lines per enemy type (27 lines).  
+**Why:** Players can't react to invisible attacks. Telegraph creates "what do I do about THIS" decision layer.  
+**Size:** M (120 lines — AI interface extension + narration data)
+
+#### 4. Mid-Combat Enemy Banter
+**Owner:** Fury  
+**What:** Four categories of enemy dialog:
+- Idle taunts (every 3-4 turns, 25% chance) — 3 lines/enemy
+- Reaction to player dodge — 3 lines/enemy  
+- Low HP desperation (at 35% threshold) — 2 lines/enemy  
+- Enemy crit (covered in P0)
+Total: ~100 new narration lines across 9 enemy types + 12 bosses  
+**Why:** Enemies have no personality mid-combat. Creates variety in repeated encounters.  
+**Size:** M (content + 3 hooks in CombatEngine)
+
+#### 5. Combat Phase-Aware Narration
+**Owner:** Barton + Fury  
+**What:** Add CombatPhase enum (Opening/MidFight/Desperate/Finishing) derived from HP percentages. Different narration pools fire at different phases. 30 new strings (3 pools × 5 messages).  
+**Why:** Same enemy fights feel different based on how combat flows — clean start vs desperate scramble.  
+**Size:** M (80 lines — NarrationService + data)
+
+### P2 — Stretch Goals (Higher Complexity)
+
+#### 6. Momentum Resource System (per-class)
+**Owner:** Barton  
+**What:** Each class builds a secondary resource through combat actions that unlocks enhanced abilities:
+- Warrior: Fury (+1 per hit taken/landed, at 5 = free crit)  
+- Mage: Arcane Charge (+1 per spell, at 3 = free enhanced cast)  
+- Paladin: Devotion (+1 with shield/heal, at 4 = next smite stuns)  
+- Ranger: Focus (+1 per turn without damage, at 3 = armor-ignore)  
+**Why:** Creates strategic "when do I spend this" decisions. Rogue combo points prove the pattern works.  
+**Size:** L (250 lines — Player model + CombatEngine + display)
+
+### Deferred (Out of Scope)
+- Environmental/positional combat hooks — requires room system integration
+- Interrupt/reaction windows — requires new resource axis (stamina)
+- Enemy AI variety expansion — DefaultEnemyAI rewrite needed
+
+## Action Items
+
+| Owner | Action | Issue |
+|-------|--------|-------|
+| Barton | Cooldown HUD visibility | #TBD |
+| Fury | Enemy crit reactions (27 lines) | #TBD |
+| Barton + Fury | Enemy telegraph system | #TBD |
+| Fury | Mid-combat enemy banter (100 lines) | #TBD |
+| Barton + Fury | Phase-aware narration | #TBD |
+| Romanoff | Pre-combat test baseline (11 tests) | #TBD |
+| Barton | Momentum resource system (stretch) | #TBD |
+
+## Romanoff's Test Requirements
+
+**Before ANY combat feature PR merges, add these 11 baseline tests:**
+1. Turn loop phase ordering test
+2. Cooldown block + tick tests (2 tests)  
+3. Ability damage quantification (4 tests across classes)
+4. Multi-effect status interaction (3 tests)
+5. Boss phase transition threshold test
+
+**Narration testing strategy:**
+- Assert *that hooks fired*, not *which strings returned*
+- Use event-based contract tests, not string matching
+- Keep content tests separate from behavior tests
+
+## Notes
+
+### Technical Debt Context
+- CombatEngine.cs is 1,259 lines — decomposition stubs exist (#1203) but logic migration incomplete
+- Changes should wire through interface layers (IEnemyAI, IAttackResolver) not inline into monolith
+- Enemy crit tracking doesn't exist on enemy side — needs one-liner bool enemyCrit check
+
+### Risk Assessment
+All P0 and P1 changes are LOW risk except narration hook timing (MEDIUM). P2 momentum system is MEDIUM risk due to CombatEngine state machine expansion.
+
+### Estimated Scope
+- P0: 2-3 sessions total
+- P1: 5-6 sessions total  
+- P2: 3-4 sessions
+- Test baseline: 1-2 sessions
+
+**Total: 11-15 sessions for P0+P1+tests, 14-19 with P2**

--- a/.ai-team/log/2026-03-08-combat-improvements-wave1.md
+++ b/.ai-team/log/2026-03-08-combat-improvements-wave1.md
@@ -1,0 +1,44 @@
+# Session: Combat Improvements Wave 1
+**Date:** 2026-03-08  
+**Requested by:** Anthony
+
+## Team Work
+
+| Agent | Work Item | PR | Status |
+|-------|-----------|-----|--------|
+| Romanoff | Combat baseline tests (Issue #1273) | #1277 | ✅ Merged |
+| Barton | Cooldown HUD visibility (Issue #1268) | #1276 | ✅ Merged |
+| Fury | Enemy crit reactions (Issue #1269) | #1275 | ✅ Merged |
+
+## Decisions Made
+
+### Combat Improvement Plan (3-Phase Approach)
+- **P0 Quick Wins:** Cooldown HUD + enemy crit reactions (2-3 sessions)
+- **P1 Core:** Telegraph system + banter + phase-aware narration (5-6 sessions)
+- **P2 Stretch:** Momentum resource system (3-4 sessions)
+
+**Key finding:** Cooldowns work correctly but lack visibility. This PR fixes the display gap.
+
+### Cooldown HUD Pattern (Barton)
+Use default interface methods on `IDisplayService` for display-only features rather than abstract members. Only `SpectreLayoutDisplayService` overrides; test stubs inherit no-op. Reduces implementation burden from 5 files to 1.
+
+### Narration Test Pattern (Romanoff)
+- Assert narration via message counts + ordering, not string content
+- Boss phases via `FiredPhases` HashSet, not display messages
+- Ability tests call `UseAbility()` directly to isolate pipeline
+- Pre-combat status effects via `StatusEffectManager` injection
+- Use `player.MaxHP` sentinel for damage assertions, not hardcoded HP
+
+### Enemy Crit Reactions (Fury)
+All 31 enemy types now have personality-driven crit reactions. Static dictionary mirrors existing narration pattern. 93 total lines added covering all archetypes (Goblin, Skeleton, Dark Knight, Wraith, Dragon, etc.). Integrated via hook in CombatEngine.PerformEnemyTurn().
+
+## Dependencies Established
+
+**Blocker:** No combat PRs merge until Romanoff's baseline tests exist (PR #1277).
+
+## Scope Summary
+
+- Test baseline: 1-2 sessions
+- P0 complete: 2-3 sessions
+- Total P0+P1+tests: 8-11 sessions
+- Content volume: ~184 lines (crit reactions, telegraphs, banter, phase narration)


### PR DESCRIPTION
Session log for 2026-03-08 combat improvements wave 1.

## Changes
- Logged wave 1 combat improvement session outcomes
- Merged 4 decision files from inbox:
  - Coulson's combat improvement plan (3-phase approach)
  - Barton's cooldown HUD pattern (default interface methods)
  - Romanoff's testing patterns (narration assertions, pre-combat setup)
  - Fury's enemy crit reactions (93 lines, 31 enemy types)
- Updated agent histories
- Deleted inbox files after merge

## Scope
All changes isolated to `.ai-team/` as per Scribe charter.