### PR TITLE
devops: sync coverage.sh threshold to 70% to match CI

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -4,17 +4,18 @@
 # Usage: bash scripts/coverage.sh
 #
 # Output: coverage summary in the terminal + opencover XML in Dungnz.Tests/coverage.opencover.xml
-# Threshold: 80% line coverage (Anthony directive)
+# Threshold: 70% line coverage (CI gate — lowered from 80% per issue #906 after P0/P1
+#             code additions outpaced test growth; restore to 80% tracked in #906)
 
 set -e
 
-echo "▶ Running tests with coverage (threshold: 80% line)..."
+echo "▶ Running tests with coverage (threshold: 70% line)..."
 dotnet test \
   --no-build \
   --verbosity normal \
   /p:CollectCoverage=true \
   /p:CoverletOutputFormat=opencover \
-  /p:Threshold=80 \
+  /p:Threshold=70 \
   /p:ThresholdType=line \
   /p:CoverletOutput=Dungnz.Tests/coverage.opencover.xml
 


### PR DESCRIPTION
Closes #1228

## What
Updated `scripts/coverage.sh` to use 70% line coverage threshold, matching the CI gate in `squad-ci.yml`.

## Why
The script was hardcoded to 80% (comment said "Anthony directive") while CI has used 70% since issue #906 lowered the floor. A developer running the script locally would fail at 70–79% coverage even though CI would pass — a confusing and incorrect divergence. CI is the authoritative gate; the local script exists solely to mirror it for fast local feedback.

## Changes
- `scripts/coverage.sh`: threshold 80 → 70, echo message updated, comment updated to reference #906 and the restoration path