### PR TITLE
devops: add restore step and NuGet cache to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,17 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Restore dependencies
+      run: dotnet restore Dungnz.slnx
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
@@ -33,7 +44,7 @@ jobs:
         queries: security-and-quality
 
     - name: Build
-      run: dotnet build Dungnz.csproj --configuration Release --no-incremental
+      run: dotnet build Dungnz.csproj --configuration Release --no-restore --no-incremental
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Closes #1231

## What
Added explicit `dotnet restore Dungnz.slnx` step and NuGet package caching to `codeql.yml`, and updated the build step to use `--no-restore`.

## Why
The CodeQL workflow was the only workflow without an explicit restore step, making it inconsistent with `squad-ci.yml`, `squad-release.yml`, and `smoke-test.yml`. While `dotnet build` implicitly restores, relying on implicit restore is brittle — if `--no-restore` is ever added (e.g., as a performance optimisation matching other workflows), the build would silently break.

NuGet caching matches the pattern in `squad-ci.yml`: `actions/cache@v4` keyed on `hashFiles('**/*.csproj')`.

## Changes
- `.github/workflows/codeql.yml`: added Cache NuGet packages step, added Restore dependencies step, added `--no-restore` to build step