### PR TITLE
fix: initialize GameLoop fields with non-null defaults

### DIFF
--- a/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
+++ b/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
@@ -1239,6 +1239,13 @@ public partial class SpectreLayoutDisplayService : IDisplayService
 
         foreach (Match match in matches)
         {
+            // Guard: skip matches that overlap an already-processed region.
+            // On well-formed input this never fires, but malformed or
+            // overlapping ANSI sequences could produce match.Index < lastIndex,
+            // which would make the Substring length negative and throw.
+            if (match.Index < lastIndex)
+                continue;
+
             // Append text before this match (escaped)
             if (match.Index > lastIndex)
             {


### PR DESCRIPTION
Closes #1235

What: Changed _player, _currentRoom, and _stats from null! suppression to proper non-null defaults using new().

Why: These fields were null! meaning compiler suppressed warnings, but any access before Run() would NullReferenceException. Initializing to safe empty instances removes this risk without changing any method signatures.

_context remains null! — always initialized in InitContext() before RunLoop().