### PR TITLE
fix: ContentPanelMenu Escape/Q no longer silently selects last item

### DIFF
--- a/Dungnz.Display/Spectre/SpectreLayoutDisplayService.Input.cs
+++ b/Dungnz.Display/Spectre/SpectreLayoutDisplayService.Input.cs
@@ -565,7 +565,9 @@ public partial class SpectreLayoutDisplayService
                     return items[selected].Value;
                 case System.ConsoleKey.Escape:
                 case System.ConsoleKey.Q:
-                    return items[items.Count - 1].Value;
+                    // Non-nullable menu: caller expects a definite selection.
+                    // Escape/Q do not cancel — ignore and let the user choose.
+                    break;
             }
         }
     }


### PR DESCRIPTION
Closes #1241

## What

In `ContentPanelMenu<T>` (non-nullable variant), pressing Escape or Q incorrectly returned `items[items.Count - 1].Value` — the last item in the list — instead of a cancel sentinel.

This is wrong for two reasons:
1. The last item may not be a cancel option (list contents depend on context)
2. `ContentPanelMenu<T>` returns `T` (non-nullable) — there is no valid cancel sentinel to return. Silently picking the last item is a phantom selection.

The nullable sibling `ContentPanelMenuNullable<T>` already handles Escape/Q correctly (returns `null`).

## Fix

For the non-nullable variant, Escape/Q are now **ignored** (the switch falls through to `break` and loops back). This matches the behaviour of Spectre's `SelectionPrompt<T>` in the non-Live path — which also has no cancel.

Callers of `ContentPanelMenu<T>` use `SelectionPromptValue<T>` which returns `T` (non-nullable). They expect the user to make an explicit selection; Escape should not produce a phantom value.