### PR TITLE
fix: remove FinalFloor local const copies, use DungeonGenerator.FinalFloor directly

### DIFF
--- a/Dungnz.Engine/Commands/AscendCommandHandler.cs
+++ b/Dungnz.Engine/Commands/AscendCommandHandler.cs
@@ -5,8 +5,6 @@ using Dungnz.Systems;
 
 internal sealed class AscendCommandHandler : ICommandHandler
 {
-    private const int FinalFloor = DungeonGenerator.FinalFloor;
-
     public void Handle(string argument, CommandContext context)
     {
         if (!context.CurrentRoom.IsEntrance)
@@ -44,7 +42,7 @@ internal sealed class AscendCommandHandler : ICommandHandler
         context.Display.ShowMessage($"You ascend back to floor {context.CurrentFloor}.");
 
         var ascendVariant = DungeonVariant.ForFloor(context.CurrentFloor);
-        context.Display.ShowFloorBanner(context.CurrentFloor, FinalFloor, ascendVariant);
+        context.Display.ShowFloorBanner(context.CurrentFloor, DungeonGenerator.FinalFloor, ascendVariant);
         context.Display.ShowRoom(context.CurrentRoom);
         context.Display.ShowMap(context.CurrentRoom, context.CurrentFloor);
     }

--- a/Dungnz.Engine/Commands/DescendCommandHandler.cs
+++ b/Dungnz.Engine/Commands/DescendCommandHandler.cs
@@ -5,7 +5,6 @@ using Dungnz.Systems;
 
 internal sealed class DescendCommandHandler : ICommandHandler
 {
-    private const int FinalFloor = DungeonGenerator.FinalFloor;
 
     public void Handle(string argument, CommandContext context)
     {
@@ -16,7 +15,7 @@ internal sealed class DescendCommandHandler : ICommandHandler
             return;
         }
 
-        if (context.CurrentFloor >= FinalFloor)
+        if (context.CurrentFloor >= DungeonGenerator.FinalFloor)
         {
             context.Stats.FinalLevel = context.Player.Level;
             context.Stats.TimeElapsed = DateTime.UtcNow - context.RunStart;
@@ -51,7 +50,7 @@ internal sealed class DescendCommandHandler : ICommandHandler
         context.FloorEntranceRoom = newStart;
         context.CurrentRoom.Visited = true;
         var descendVariant = DungeonVariant.ForFloor(context.CurrentFloor);
-        context.Display.ShowFloorBanner(context.CurrentFloor, FinalFloor, descendVariant);
+        context.Display.ShowFloorBanner(context.CurrentFloor, DungeonGenerator.FinalFloor, descendVariant);
         context.Display.ShowMessage(descendVariant.EntryMessage);
         context.Display.ShowRoom(context.CurrentRoom);
         context.Display.ShowMap(context.CurrentRoom, context.CurrentFloor);

--- a/Dungnz.Engine/Commands/GoCommandHandler.cs
+++ b/Dungnz.Engine/Commands/GoCommandHandler.cs
@@ -6,8 +6,6 @@ using Microsoft.Extensions.Logging;
 
 internal sealed class GoCommandHandler : ICommandHandler
 {
-    private const int FinalFloor = DungeonGenerator.FinalFloor;
-
     private static readonly string[] _postCombatLines =
     {
         "The room falls silent. Nothing moves but the dust settling around the fallen {0}.",
@@ -183,7 +181,7 @@ internal sealed class GoCommandHandler : ICommandHandler
         // Check win/floor condition
         if (context.CurrentRoom.IsExit && context.CurrentRoom.Enemy == null)
         {
-            if (context.CurrentFloor >= FinalFloor)
+            if (context.CurrentFloor >= DungeonGenerator.FinalFloor)
             {
                 context.Stats.FinalLevel = context.Player.Level;
                 context.Stats.TimeElapsed = DateTime.UtcNow - context.RunStart;

--- a/Dungnz.Engine/Commands/StatsCommandHandler.cs
+++ b/Dungnz.Engine/Commands/StatsCommandHandler.cs
@@ -2,11 +2,9 @@ namespace Dungnz.Engine.Commands;
 
 internal sealed class StatsCommandHandler : CommandHandlerBase
 {
-    private const int FinalFloor = DungeonGenerator.FinalFloor;
-
     protected override void HandleCore(string argument, CommandContext context)
     {
         context.Display.ShowPlayerStats(context.Player);
-        context.Display.ShowMessage($"Floor: {context.CurrentFloor} / {FinalFloor}");
+        context.Display.ShowMessage($"Floor: {context.CurrentFloor} / {DungeonGenerator.FinalFloor}");
     }
 }

--- a/Dungnz.Engine/GameLoop.cs
+++ b/Dungnz.Engine/GameLoop.cs
@@ -41,8 +41,6 @@ public class GameLoop
     /// <summary>Set to <see langword="true"/> when the run ends (win, death) to break the Run() loop.</summary>
     private bool _gameOver = false;
 
-    private const int FinalFloor = DungeonGenerator.FinalFloor;
-
     private readonly Dictionary<CommandType, ICommandHandler> _handlers;
     private CommandContext _context = null!;
 


### PR DESCRIPTION
Closes #1234

FinalFloor was re-declared as a local const in 5 places (GoCommandHandler, DescendCommandHandler, AscendCommandHandler, StatsCommandHandler, GameLoop) all pointing back to DungeonGenerator.FinalFloor anyway.

Removed all local const copies. All usages now reference DungeonGenerator.FinalFloor directly. Single source of truth.