### PR TITLE
fix: close open Spectre tag before switching colors (crit hit MarkupException) (#1304)

### DIFF
--- a/Dungnz.Display/Spectre/AnsiMarkupConverter.cs
+++ b/Dungnz.Display/Spectre/AnsiMarkupConverter.cs
@@ -1,0 +1,126 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace Dungnz.Display.Spectre;
+
+/// <summary>
+/// Converts ANSI inline escape codes to Spectre.Console markup, and strips ANSI codes
+/// from plain-text output. Extracted from <see cref="SpectreLayoutDisplayService"/> for
+/// testability — the logic is pure string transformation with no terminal dependencies.
+/// </summary>
+internal static class AnsiMarkupConverter
+{
+    private static readonly Regex AnsiEscapePattern = new(@"\x1B\[[0-9;]*m", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips all ANSI escape sequences from <paramref name="input"/>, returning plain text
+    /// suitable for log output or terminals that do not support color codes.
+    /// </summary>
+    internal static string StripAnsiCodes(string input) =>
+        AnsiEscapePattern.Replace(input, string.Empty);
+
+    /// <summary>
+    /// Translates ANSI inline color/bold escape codes in <paramref name="input"/> to
+    /// equivalent Spectre.Console markup tags. Plain text segments are escaped with
+    /// <see cref="Markup.Escape"/> so that literal brackets are never misinterpreted.
+    /// </summary>
+    /// <remarks>
+    /// Handles nested ANSI sequences (e.g. a bold-yellow outer wrap that contains an
+    /// inner bright-red damage number) by closing the current open tag before opening a
+    /// new one whenever the color/bold state changes mid-message.
+    /// </remarks>
+    internal static string ConvertAnsiInlineToSpectre(string input)
+    {
+        var matches = AnsiEscapePattern.Matches(input);
+        if (matches.Count == 0)
+            return Markup.Escape(input);
+
+        var result = new StringBuilder();
+        var lastIndex = 0;
+        var isBold = false;
+        var currentColor = "";
+        var isTagOpen = false;
+
+        foreach (Match match in matches)
+        {
+            if (match.Index > lastIndex)
+            {
+                var plainText = input.Substring(lastIndex, match.Index - lastIndex);
+
+                if ((isBold || !string.IsNullOrEmpty(currentColor)) && !string.IsNullOrEmpty(plainText))
+                {
+                    // Close any previously open tag before opening a new one — this handles
+                    // the case where a color change occurs mid-message (e.g. crit hits wrap
+                    // the whole message in bold-yellow while the damage number is bright-red).
+                    if (isTagOpen)
+                        result.Append("[/]");
+
+                    result.Append('[');
+                    if (isBold) result.Append("bold");
+                    if (isBold && !string.IsNullOrEmpty(currentColor)) result.Append(' ');
+                    if (!string.IsNullOrEmpty(currentColor)) result.Append(currentColor);
+                    result.Append(']');
+                    isTagOpen = true;
+                }
+
+                result.Append(Markup.Escape(plainText));
+            }
+
+            var code = match.Value;
+            if (code == "\u001b[0m") // Reset
+            {
+                if (isTagOpen)
+                {
+                    result.Append("[/]");
+                    isTagOpen = false;
+                }
+                isBold = false;
+                currentColor = "";
+            }
+            else if (code == "\u001b[1m") // Bold
+            {
+                isBold = true;
+            }
+            else // Color code
+            {
+                currentColor = code switch
+                {
+                    "\u001b[91m" => "red",
+                    "\u001b[32m" => "green",
+                    "\u001b[33m" => "yellow",
+                    "\u001b[36m" => "cyan",
+                    "\u001b[37m" => "grey",
+                    "\u001b[34m" => "blue",
+                    "\u001b[97m" => "white",
+                    _            => ""
+                };
+            }
+
+            lastIndex = match.Index + match.Length;
+        }
+
+        if (lastIndex < input.Length)
+        {
+            var plainText = input.Substring(lastIndex);
+            if ((isBold || !string.IsNullOrEmpty(currentColor)) && !string.IsNullOrEmpty(plainText))
+            {
+                if (isTagOpen)
+                    result.Append("[/]");
+
+                result.Append('[');
+                if (isBold) result.Append("bold");
+                if (isBold && !string.IsNullOrEmpty(currentColor)) result.Append(' ');
+                if (!string.IsNullOrEmpty(currentColor)) result.Append(currentColor);
+                result.Append(']');
+                isTagOpen = true;
+            }
+            result.Append(Markup.Escape(plainText));
+        }
+
+        if (isTagOpen)
+            result.Append("[/]");
+
+        return result.ToString();
+    }
+}

--- a/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
+++ b/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Text.RegularExpressions;
 using Dungnz.Models;
 using Dungnz.Systems;
 using Spectre.Console;
@@ -50,7 +49,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     // Cached ability cooldown state for combat HUD (Issue #1268)
     private IReadOnlyList<(string name, int turnsRemaining)> _cachedCooldowns = [];
 
-    private static readonly Regex AnsiEscapePattern = new(@"\x1B\[[0-9;]*m", RegexOptions.Compiled);
+
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SpectreLayoutDisplayService"/> class.
@@ -1241,99 +1240,10 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     };
 
     private static string StripAnsiCodes(string input) =>
-        AnsiEscapePattern.Replace(input, string.Empty);
+        AnsiMarkupConverter.StripAnsiCodes(input);
 
-    private static string ConvertAnsiInlineToSpectre(string input)
-    {
-        var matches = AnsiEscapePattern.Matches(input);
-        if (matches.Count == 0)
-            return Markup.Escape(input);
-
-        var result = new StringBuilder();
-        var lastIndex = 0;
-        var isBold = false;
-        var currentColor = "";
-        var isTagOpen = false;
-
-        foreach (Match match in matches)
-        {
-            // Append text before this match (escaped)
-            if (match.Index > lastIndex)
-            {
-                var plainText = input.Substring(lastIndex, match.Index - lastIndex);
-                
-                // If we have bold or color accumulated, open tag before text
-                if ((isBold || !string.IsNullOrEmpty(currentColor)) && !string.IsNullOrEmpty(plainText))
-                {
-                    result.Append('[');
-                    if (isBold)
-                        result.Append("bold ");
-                    if (!string.IsNullOrEmpty(currentColor))
-                        result.Append(currentColor);
-                    result.Append(']');
-                    isTagOpen = true;
-                }
-                
-                result.Append(Markup.Escape(plainText));
-            }
-
-            // Process ANSI code
-            var code = match.Value;
-            if (code == "\u001b[0m") // Reset
-            {
-                if (isTagOpen)
-                {
-                    result.Append("[/]");
-                    isTagOpen = false;
-                }
-                isBold = false;
-                currentColor = "";
-            }
-            else if (code == "\u001b[1m") // Bold
-            {
-                isBold = true;
-            }
-            else // Color code
-            {
-                currentColor = code switch
-                {
-                    "\u001b[91m" => "red",
-                    "\u001b[32m" => "green",
-                    "\u001b[33m" => "yellow",
-                    "\u001b[36m" => "cyan",
-                    "\u001b[37m" => "grey",
-                    "\u001b[34m" => "blue",
-                    "\u001b[97m" => "white",
-                    _ => ""
-                };
-            }
-
-            lastIndex = match.Index + match.Length;
-        }
-
-        // Append remaining text
-        if (lastIndex < input.Length)
-        {
-            var plainText = input.Substring(lastIndex);
-            if ((isBold || !string.IsNullOrEmpty(currentColor)) && !string.IsNullOrEmpty(plainText))
-            {
-                result.Append('[');
-                if (isBold)
-                    result.Append("bold ");
-                if (!string.IsNullOrEmpty(currentColor))
-                    result.Append(currentColor);
-                result.Append(']');
-                isTagOpen = true;
-            }
-            result.Append(Markup.Escape(plainText));
-        }
-
-        // Close tag if still open
-        if (isTagOpen)
-            result.Append("[/]");
-
-        return result.ToString();
-    }
+    private static string ConvertAnsiInlineToSpectre(string input) =>
+        AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
 }
 
 

--- a/Dungnz.Tests/Display/AnsiMarkupConverterTests.cs
+++ b/Dungnz.Tests/Display/AnsiMarkupConverterTests.cs
@@ -1,0 +1,154 @@
+using Dungnz.Display.Spectre;
+using Spectre.Console;
+
+namespace Dungnz.Tests.Display;
+
+/// <summary>
+/// Unit tests for <see cref="AnsiMarkupConverter"/> — the ANSI-to-Spectre markup
+/// conversion and stripping utilities extracted from SpectreLayoutDisplayService.
+/// </summary>
+public class AnsiMarkupConverterTests
+{
+    // ── ConvertAnsiInlineToSpectre ──────────────────────────────────────────
+
+    [Fact]
+    public void NoAnsiCodes_ReturnsMarkupEscapedInput()
+    {
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre("Hello world");
+        Assert.Equal("Hello world", result);
+    }
+
+    [Fact]
+    public void PlainTextWithBrackets_EscapesBracketsForSpectre()
+    {
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre("dmg [10]");
+        Assert.Equal("dmg [[10]]", result);
+        Assert.False(result.Contains("<"), "Should not produce angle brackets");
+    }
+
+    [Fact]
+    public void SimpleColorWrap_ProducesClosedTag()
+    {
+        // "\x1b[91m15\x1b[0m" — bright-red "15"
+        var input = "\x1b[91m15\x1b[0m";
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
+
+        Assert.Equal("[red]15[/]", result);
+        AssertValidSpectreMarkup(result);
+    }
+
+    [Fact]
+    public void SimpleBoldWrap_ProducesClosedTag()
+    {
+        var input = "\x1b[1mBold text\x1b[0m";
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
+
+        Assert.Equal("[bold]Bold text[/]", result);
+        AssertValidSpectreMarkup(result);
+    }
+
+    [Fact]
+    public void BoldAndColor_ProducesClosedTag()
+    {
+        var input = "\x1b[33m\x1b[1mYellow bold\x1b[0m";
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
+
+        Assert.Contains("[bold yellow]", result);
+        Assert.Contains("[/]", result);
+        AssertValidSpectreMarkup(result);
+    }
+
+    /// <summary>
+    /// Regression test for bug #1304.
+    /// ColorizeDamage for crits wraps the message in bold-yellow while embedding a
+    /// bright-red damage number. The outer bold-yellow tag must be properly closed
+    /// before the inner bright-red tag is opened.
+    /// </summary>
+    [Fact]
+    public void NestedAnsiCodes_CritDamage_AllTagsProperlyClosedAndValid()
+    {
+        // Simulates the exact ANSI output from ColorizeDamage for a critical hit:
+        //   ColorCodes.Colorize(message-with-bright-red-damage, Yellow + Bold)
+        // which produces:  \x1b[33m\x1b[1m<text>\x1b[91m<dmg>\x1b[0m<text>\x1b[0m
+        const string input =
+            "\x1b[33m\x1b[1m\U0001F4A5 CRUSHING BLOW! You hit the Goblin for \x1b[91m42\x1b[0m damage!\x1b[0m";
+
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
+
+        // Must not contain any unclosed/improperly-stacked tags
+        AssertValidSpectreMarkup(result);
+
+        // Outer bold-yellow and inner bold-red (bold is still active at the inner code point)
+        // must both appear and be individually closed
+        Assert.Contains("[bold yellow]", result);
+        Assert.Contains("[bold red]42[/]", result);
+    }
+
+    [Fact]
+    public void NestedAnsiCodes_TextBeforeAndAfterInnerCode_ProducesValidMarkup()
+    {
+        // "\x1b[33m[prefix] \x1b[91m[number]\x1b[0m [suffix]\x1b[0m"
+        var input = "\x1b[33mprefix \x1b[91m99\x1b[0m suffix\x1b[0m";
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
+
+        AssertValidSpectreMarkup(result);
+
+        // Outer yellow and inner red content must both be present
+        Assert.Contains("[yellow]prefix ", result);
+        Assert.Contains("[red]99[/]", result);
+        Assert.Contains("suffix", result);
+    }
+
+    [Fact]
+    public void MultipleColorSegments_EachProducesClosedTag()
+    {
+        // Two separate colored segments in the same string
+        var input = "\x1b[32mgreen\x1b[0m and \x1b[91mred\x1b[0m";
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
+
+        Assert.Equal("[green]green[/] and [red]red[/]", result);
+        AssertValidSpectreMarkup(result);
+    }
+
+    [Fact]
+    public void UnknownAnsiCode_TreatedAsResetProducesNoTag()
+    {
+        // Unknown code \x1b[35m (magenta, not mapped) → currentColor = ""
+        var input = "\x1b[35mtext\x1b[0m";
+        var result = AnsiMarkupConverter.ConvertAnsiInlineToSpectre(input);
+
+        // Unknown color → no tag opened, plain escaped text
+        Assert.Equal("text", result);
+    }
+
+    // ── StripAnsiCodes ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void StripAnsiCodes_RemovesAllEscapeSequences()
+    {
+        var input = "\x1b[33m\x1b[1mhello\x1b[0m \x1b[91mworld\x1b[0m";
+        var result = AnsiMarkupConverter.StripAnsiCodes(input);
+
+        Assert.Equal("hello world", result);
+    }
+
+    [Fact]
+    public void StripAnsiCodes_NoAnsiCodes_ReturnsOriginal()
+    {
+        const string input = "plain text";
+        Assert.Equal(input, AnsiMarkupConverter.StripAnsiCodes(input));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Asserts that the given string is valid Spectre.Console markup by attempting to
+    /// parse it. Spectre throws <see cref="InvalidOperationException"/> on malformed
+    /// markup (unclosed tags, unknown styles, etc.).
+    /// </summary>
+    private static void AssertValidSpectreMarkup(string markup)
+    {
+        var ex = Record.Exception(() => new Markup(markup));
+        Assert.Null(ex); // no exception = valid markup
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a crash that occurs on every critical hit in combat.

## Root Cause
`ColorizeDamage` for crits produces nested ANSI codes:
- Outer: bold-yellow wrapping the entire crit message  
- Inner: bright-red wrapping just the damage number

`ConvertAnsiInlineToSpectre` in SpectreLayoutDisplayService was not closing the currently-open Spectre tag before switching to a new color. This produced malformed markup:
```
[bold yellow]💥 CRUSHING BLOW! You hit for [bold red]42[/] damage!
                                             ↑ outer tag never closed
```
`new Markup(content)` in `RefreshContentPanel` throws `InvalidOperationException` on unclosed tags.

## Fix
Before opening a new tag for the next text segment, close any currently-open tag:
```csharp
if (isTagOpen)
    result.Append("[/]");
```

Also fixed: bold-only tags were producing `[bold ]` (trailing space) which Spectre rejects — now produces `[bold]` correctly.

## Refactor
Extracted `ConvertAnsiInlineToSpectre` and `StripAnsiCodes` to new `internal static class AnsiMarkupConverter`. `Dungnz.Display` already had `InternalsVisibleTo("Dungnz.Tests")` so direct unit tests are now possible.

## Tests
11 new tests in `AnsiMarkupConverterTests`:
- No ANSI codes (passthrough with escaping)
- Simple color wrap
- Simple bold wrap
- Bold + color
- **Nested ANSI codes — crit hit scenario (regression for #1304)**
- Text before/after inner code
- Multiple color segments
- Unknown ANSI code (treated as no-color)
- StripAnsiCodes variants

All 1883 tests pass. 0 failures.

Closes #1304
Closes #1305