### PR TITLE
fix: escape CHARGED markup + cache player in ShowCombatStatus (#1324, #1325)

### DIFF
--- a/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
+++ b/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
@@ -446,7 +446,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
                 _                   => "Momentum"
             };
             var dots = new string('●', momentum.Current) + new string('○', momentum.Maximum - momentum.Current);
-            var chargedSuffix = momentum.IsCharged ? " [bold cyan][CHARGED][/]" : string.Empty;
+            var chargedSuffix = momentum.IsCharged ? " [bold cyan][[CHARGED]][/]" : string.Empty;
             sb.AppendLine($"[yellow]✦ {label}[/] {dots}{chargedSuffix}");
         }
 
@@ -502,7 +502,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
                 _                   => "Momentum"
             };
             var dots = new string('●', momentum.Current) + new string('○', momentum.Maximum - momentum.Current);
-            var chargedSuffix = momentum.IsCharged ? " [bold cyan][CHARGED][/]" : string.Empty;
+            var chargedSuffix = momentum.IsCharged ? " [bold cyan][[CHARGED]][/]" : string.Empty;
             sb.AppendLine($"[yellow]✦ {label}[/] {dots}{chargedSuffix}");
         }
 
@@ -768,6 +768,7 @@ public partial class SpectreLayoutDisplayService : IDisplayService
         IReadOnlyList<ActiveEffect> playerEffects,
         IReadOnlyList<ActiveEffect> enemyEffects)
     {
+        _cachedPlayer = player;              // FIX: cache player so RenderCombatStatsPanel fires
         // Cache enemy state for Stats panel persistence (Issue #1312)
         _cachedCombatEnemy = enemy;
         _cachedEnemyEffects = enemyEffects;


### PR DESCRIPTION
## Summary

Fixes two bugs in `Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs`.

### Bug 1 — CHARGED markup crash (Closes #1324)

Spectre Console parsed `[CHARGED]` as a colour/style tag name, found none, and threw `InvalidOperationException`. Fixed by escaping both occurrences with double brackets (`[[CHARGED]]`), which Spectre renders as literal `[CHARGED]` text. This pattern is already used elsewhere in the file for effect badges.

### Bug 2 — Enemy stats never shown in Stats panel (Closes #1325)

`ShowCombatStatus` cached the enemy but never cached the player, so the `_cachedPlayer != null` guard always failed and `RenderCombatStatsPanel` was never called during normal combat (only after a level-up set `_cachedPlayer`). Fixed by adding `_cachedPlayer = player;` as the first line of the method.

## Changes
- `Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs`: 3 surgical line changes, no logic impact outside the two fixes.

## Verification
- `dotnet build Dungnz.slnx --no-incremental` → **0 errors, 0 warnings**
- `dotnet test --no-build` → **1898 passed, 4 skipped, 0 failed**