### PR TITLE
Fix enemy stats never visible: render in Gear panel (fixes #1328)

### DIFF
--- a/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
+++ b/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
@@ -453,6 +453,8 @@ public partial class SpectreLayoutDisplayService : IDisplayService
         UpdateStatsPanel(sb.ToString().TrimEnd());
     }
 
+    // Renders player-only stats into the Stats panel during combat.
+    // Enemy stats are rendered separately into the Gear panel by RenderEnemyStatsPanel.
     private void RenderCombatStatsPanel(Player player, Enemy enemy, IReadOnlyList<ActiveEffect> enemyEffects)
     {
         var sb = new StringBuilder();
@@ -506,12 +508,17 @@ public partial class SpectreLayoutDisplayService : IDisplayService
             sb.AppendLine($"[yellow]✦ {label}[/] {dots}{chargedSuffix}");
         }
 
-        // Separator
-        sb.AppendLine();
-        sb.AppendLine("[grey]──────────────────[/]");
-        sb.AppendLine();
+        UpdateStatsPanel(sb.ToString().TrimEnd());
+        RenderEnemyStatsPanel(enemy, enemyEffects);
+    }
 
-        // Enemy section (Issue #1312)
+    // Renders enemy stats into the Gear panel during combat.
+    // The Gear panel (50% screen height) has enough vertical space to show full enemy details.
+    // ShowRoom restores the Gear panel to player gear display after combat ends.
+    private void RenderEnemyStatsPanel(Enemy enemy, IReadOnlyList<ActiveEffect> enemyEffects)
+    {
+        var sb = new StringBuilder();
+
         sb.AppendLine($"🐉 [bold]{Markup.Escape(enemy.Name)}[/]");
 
         if (enemy is Dungnz.Systems.Enemies.DungeonBoss boss)
@@ -563,8 +570,13 @@ public partial class SpectreLayoutDisplayService : IDisplayService
             sb.AppendLine();
         }
 
-        UpdateStatsPanel(sb.ToString().TrimEnd());
+        var panel = new Panel(new Markup(sb.ToString().TrimEnd()))
+            .Header("[bold red]🐉 Enemy[/]")
+            .Border(BoxBorder.Rounded)
+            .BorderColor(Color.Red);
+        _ctx.UpdatePanel(SpectreLayout.Panels.Gear, panel);
     }
+
 
     private void RenderGearPanel(Player player)
     {
@@ -790,10 +802,15 @@ public partial class SpectreLayoutDisplayService : IDisplayService
     {
         _cachedPlayer = player;
         if (_cachedCombatEnemy != null)
+        {
+            // In combat: update player stats panel and refresh enemy panel; do not overwrite Gear
             RenderCombatStatsPanel(player, _cachedCombatEnemy, _cachedEnemyEffects);
+        }
         else
+        {
             RenderStatsPanel(player);
-        RenderGearPanel(player);
+            RenderGearPanel(player);
+        }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Root cause

Enemy stats were always being rendered into the **Stats panel** (top-right, 20% height, ~8 visible rows). Player stats alone consume 10–12 lines, so the enemy section was perpetually below the fold — technically rendered, but never visible.

## What changed

- **New `RenderEnemyStatsPanel`** — renders enemy name, HP bar, ATK/DEF, regen, trait badges, and active effects into the **Gear panel** (50% height, 30% width — plenty of space). Uses an 🐉 Enemy header with red border during combat.
- **`RenderCombatStatsPanel`** — now renders player-only stats, then delegates to `RenderEnemyStatsPanel`. Separator and enemy section removed.
- **`ShowPlayerStats` fix** — was unconditionally calling `RenderGearPanel`, overwriting the enemy panel even during combat (e.g. on level-up). Now only calls `RenderGearPanel` when not in combat.
- **Post-combat restore** — `ShowRoom` already cleared `_cachedCombatEnemy` and called `RenderGearPanel`, so gear is correctly restored after combat with no additional changes needed.

## Tests

All 1898 tests pass (4 pre-existing skips).