### PR TITLE
test(display): adversarial markup + panel line count assertions

### DIFF
--- a/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
+++ b/Dungnz.Display/Spectre/SpectreLayoutDisplayService.cs
@@ -469,8 +469,6 @@ public partial class SpectreLayoutDisplayService : IDisplayService
 
     // Renders player-only stats into the Stats panel during combat.
     // Enemy stats are rendered separately into the Gear panel by RenderEnemyStatsPanel.
-    // Renders player-only stats into the Stats panel during combat.
-    // Enemy stats are rendered separately into the Gear panel by RenderEnemyStatsPanel.
     private void RenderCombatStatsPanel(Player player, Enemy enemy, IReadOnlyList<ActiveEffect> enemyEffects)
     {
         UpdateStatsPanel(BuildPlayerStatsPanelMarkup(player, _cachedCooldowns));

--- a/Dungnz.Tests/Display/MarkupAdversarialTests.cs
+++ b/Dungnz.Tests/Display/MarkupAdversarialTests.cs
@@ -230,14 +230,13 @@ public sealed class MarkupAdversarialTests : IDisposable
 
     /// <summary>
     /// The Stats panel is 20% of the terminal height (~8 visible rows).
-    /// BuildPlayerStatsPanelMarkup must not produce more than 8 newlines for the
-    /// typical warrior-in-combat state (HP+MP bars, ATK/DEF, Gold, XP, Momentum).
-    /// Hardcoded to 8 — Issue #1334 will move this to LayoutConstants.cs.
+    /// BuildPlayerStatsPanelMarkup must not produce more than <see cref="LayoutConstants.StatsPanelHeight"/> newlines
+    /// for the typical warrior-in-combat state (HP+MP bars, ATK/DEF, Gold, XP, Momentum).
     /// </summary>
     [Fact]
     public void BuildPlayerStatsPanelMarkup_TypicalCombatState_RendersWithinStatsPanelBounds()
     {
-        const int maxLines = 8;
+        const int maxLines = LayoutConstants.StatsPanelHeight;
 
         var player = new PlayerBuilder()
             .Named("Warrior")
@@ -257,13 +256,13 @@ public sealed class MarkupAdversarialTests : IDisposable
     }
 
     /// <summary>
-    /// Even with CHARGED momentum, the panel must stay within 8 lines.
+    /// Even with CHARGED momentum, the panel must stay within <see cref="LayoutConstants.StatsPanelHeight"/> lines.
     /// This is the worst-case for a momentum-bearing class with mana.
     /// </summary>
     [Fact]
     public void BuildPlayerStatsPanelMarkup_ChargedMomentumWithMana_RendersWithinStatsPanelBounds()
     {
-        const int maxLines = 8;
+        const int maxLines = LayoutConstants.StatsPanelHeight;
 
         var player = new PlayerBuilder()
             .Named("Mage")


### PR DESCRIPTION
Closes #1331
Closes #1332

## What
Adds adversarial markup smoke tests for all ShowXxx display methods and a RenderLineCount assertion for RenderCombatStatsPanel.

Extracts `BuildPlayerStatsPanelMarkup` as an `internal static` method from `SpectreLayoutDisplayService` — this is the testability seam. Both `RenderStatsPanel` and `RenderCombatStatsPanel` now delegate to it (no behaviour change).

## Why
Retro P0 action items. The [CHARGED] crash recurred multiple times because no test covered the rendering path with bracket content. The Stats panel overflow was invisible for multiple sessions because no test asserted rendered line counts.

## Tests Added (MarkupAdversarialTests.cs)
- `ShowCombatStatus_WithChargedStatusEffect_DoesNotThrow`
- `ShowCombatStatus_PlayerNameWithBrackets_DoesNotThrow`
- `ShowCombatStatus_EnemyNameWithBrackets_DoesNotThrow`
- `ShowRoom_DescriptionWithBrackets_DoesNotThrow`
- `ShowCombatMessage_WithBracketContent_DoesNotThrow`
- `ShowPlayerStats_PlayerNameWithBrackets_DoesNotThrow`
- `BuildPlayerStatsPanelMarkup_WithChargedMomentum_ProducesValidMarkup` ← primary regression gate
- `BuildPlayerStatsPanelMarkup_WithUnchargedMomentum_ProducesValidMarkup`
- `BuildPlayerStatsPanelMarkup_PlayerNameWithBrackets_ProducesValidMarkup`
- `BuildPlayerStatsPanelMarkup_TypicalCombatState_RendersWithinStatsPanelBounds` (≤8 lines)
- `BuildPlayerStatsPanelMarkup_ChargedMomentumWithMana_RendersWithinStatsPanelBounds` (≤8 lines)

The `[[CHARGED]]` escaping test is the primary regression gate: if someone accidentally writes `[CHARGED]` without double-bracket escaping, `new Markup()` throws `InvalidOperationException` and the test catches it before ship.

The line count is hardcoded to 8 — Issue #1334 will centralise this in `LayoutConstants.cs`.

## Verified in terminal
All tests pass: dotnet test
1909 passed, 0 failed, 4 skipped