### PR TITLE
fix: correct YAML indentation in squad-ci.yml breaking master CI

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -137,19 +137,19 @@ jobs:
               sys.exit(1)
           PYEOF
 
-       - name: Publish job summary
-         if: always()
-         run: |
-           echo "## CI Results" >> $GITHUB_STEP_SUMMARY
-           echo "" >> $GITHUB_STEP_SUMMARY
-           echo "- **Build**: ✅ Success" >> $GITHUB_STEP_SUMMARY
-           echo "- **Tests**: ✅ Passed" >> $GITHUB_STEP_SUMMARY
-           
-           # Extract coverage percentage from cobertura XML
-           if [ -f "Dungnz.Tests/coverage/coverage.cobertura.xml" ]; then
-             COVERAGE=$(grep -oP 'line-rate="\K[^"]+' Dungnz.Tests/coverage/coverage.cobertura.xml | head -1)
-             COVERAGE_PCT=$(printf "%.2f" $(echo "$COVERAGE * 100" | bc))%
-             echo "- **Coverage**: $COVERAGE_PCT (threshold: 80%)" >> $GITHUB_STEP_SUMMARY
-           else
-             echo "- **Coverage**: Unknown" >> $GITHUB_STEP_SUMMARY
-           fi
+      - name: Publish job summary
+        if: always()
+        run: |
+          echo "## CI Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build**: ✅ Success" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tests**: ✅ Passed" >> $GITHUB_STEP_SUMMARY
+          
+          # Extract coverage percentage from cobertura XML
+          if [ -f "Dungnz.Tests/coverage/coverage.cobertura.xml" ]; then
+            COVERAGE=$(grep -oP 'line-rate="\K[^"]+' Dungnz.Tests/coverage/coverage.cobertura.xml | head -1)
+            COVERAGE_PCT=$(printf "%.2f" $(echo "$COVERAGE * 100" | bc))%
+            echo "- **Coverage**: $COVERAGE_PCT (threshold: 80%)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Coverage**: Unknown" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Problem
PR #1384 merged with a YAML syntax error: the `Publish job summary` step (lines 140–155) had 7 spaces of leading indentation instead of the required 6. This caused every CI run on master to fail immediately.

## Fix
Remove the single extra leading space from all 16 lines of the `Publish job summary` step.

## Impact
This unblocks all 16 remaining open PRs that are currently blocked by broken master CI.

Fixes the regression introduced by #1384.