### PR TITLE
feat(avalonia): P3 output panel implementation

### DIFF
--- a/Dungnz.Display.Avalonia/App.axaml.cs
+++ b/Dungnz.Display.Avalonia/App.axaml.cs
@@ -32,7 +32,7 @@ public class App : Application
             
             // Create main window and ViewModel
             var mainVM = new MainWindowViewModel();
-            var displayService = new AvaloniaDisplayService();
+            var displayService = new AvaloniaDisplayService(mainVM);
             
             var mainWindow = new MainWindow
             {

--- a/Dungnz.Display.Avalonia/AvaloniaDisplayService.cs
+++ b/Dungnz.Display.Avalonia/AvaloniaDisplayService.cs
@@ -1,3 +1,7 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Avalonia.Threading;
+using Dungnz.Display.Avalonia.ViewModels;
 using Dungnz.Models;
 using Dungnz.Systems;
 
@@ -5,67 +9,746 @@ namespace Dungnz.Display.Avalonia;
 
 /// <summary>
 /// Avalonia implementation of <see cref="IDisplayService"/> (both <see cref="IGameDisplay"/> and <see cref="IGameInput"/>).
-/// This is a stub scaffold for Phase 2 — all methods return defaults.
-/// Actual rendering and input collection will be implemented in P3-P8.
+/// Phase 3: All IGameDisplay output methods implemented with Dispatcher.UIThread.InvokeAsync pattern.
+/// Phase 5-8: IGameInput methods will be implemented with async prompt dialogs.
 /// </summary>
 public class AvaloniaDisplayService : IDisplayService
 {
+    private readonly MainWindowViewModel _vm;
+    
+    // Cached state (same pattern as SpectreLayoutDisplayService)
+    private Player? _cachedPlayer;
+    private Room? _cachedRoom;
+    private int _currentFloor = 1;
+    private Enemy? _cachedCombatEnemy;
+    private IReadOnlyList<ActiveEffect> _cachedEnemyEffects = Array.Empty<ActiveEffect>();
+    private IReadOnlyList<(string name, int turnsRemaining)> _cachedCooldowns = [];
+    private bool _lowHpWarningIssued;
+
+    public AvaloniaDisplayService(MainWindowViewModel viewModel)
+    {
+        _vm = viewModel;
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // IGameDisplay Implementation (Output-only methods)
     // ══════════════════════════════════════════════════════════════════════════
 
-    // TODO: P3-P8 implementation
-    public void ShowTitle() { }
-    public void ShowEnhancedTitle() { }
-    public bool ShowIntroNarrative() => false;
-    public void ShowPrestigeInfo(PrestigeData prestige) { }
-    public void ShowFloorBanner(int floor, int maxFloor, DungeonVariant variant) { }
+    /// <inheritdoc/>
+    public void ShowTitle()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("  ██████╗ ██╗   ██╗███╗   ██╗ ██████╗ ███╗   ██╗███████╗");
+        sb.AppendLine("  ██╔══██╗██║   ██║████╗  ██║██╔════╝ ████╗  ██║╚══███╔╝");
+        sb.AppendLine("  ██║  ██║██║   ██║██╔██╗ ██║██║  ███╗██╔██╗ ██║  ███╔╝ ");
+        sb.AppendLine("  ██║  ██║██║   ██║██║╚██╗██║██║   ██║██║╚██╗██║ ███╔╝  ");
+        sb.AppendLine("  ██████╔╝╚██████╔╝██║ ╚████║╚██████╔╝██║ ╚████║███████╗");
+        sb.AppendLine("  ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝");
+        sb.AppendLine();
+        sb.Append("              A dungeon awaits...");
 
-    public void ShowRoom(Room room) { }
-    public void ShowMap(Room currentRoom, int floor = 1) { }
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString(), "🏰 DUNGNZ"));
+    }
 
-    public void ShowCombat(string message) { }
-    public void ShowCombatStatus(Player player, Enemy enemy, IReadOnlyList<ActiveEffect> playerEffects, IReadOnlyList<ActiveEffect> enemyEffects) { }
-    public void ShowCombatMessage(string message) { }
-    public void ShowColoredCombatMessage(string message, string color) { }
-    public void ShowCombatStart(Enemy enemy) { }
-    public void ShowCombatEntryFlags(Enemy enemy) { }
-    public void ShowEnemyArt(Enemy enemy) { }
-    public void ShowEnemyDetail(Enemy enemy) { }
-    public void ShowCombatHistory() { }
+    /// <inheritdoc/>
+    public void ShowEnhancedTitle()
+    {
+        ShowTitle();
+    }
 
-    public void ShowPlayerStats(Player player) { }
-    public void ShowInventory(Player player) { }
-    public void ShowEquipment(Player player) { }
-    public void ShowEquipmentComparison(Player player, Item? oldItem, Item newItem) { }
-    public void ShowItemDetail(Item item) { }
-    public void ShowLootDrop(Item item, Player player, bool isElite = false) { }
-    public void ShowGoldPickup(int amount, int newTotal) { }
-    public void ShowItemPickup(Item item, int slotsCurrent, int slotsMax, int weightCurrent, int weightMax) { }
+    /// <inheritdoc/>
+    public bool ShowIntroNarrative()
+    {
+        var narrative = "Long ago, the fortress of Dungnz stood proud against the darkness.\n" +
+                        "Now it lies in ruin, its halls crawling with monsters.\n" +
+                        "Many have ventured into its depths. Few return.\n\n" +
+                        "Will you be the one to conquer it?";
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(narrative, "📜 Lore"));
+        return false;
+    }
 
-    public void ShowShop(IEnumerable<(Item item, int price)> stock, int playerGold) { }
-    public void ShowSellMenu(IEnumerable<(Item item, int sellPrice)> items, int playerGold) { }
-    public void ShowCraftRecipe(string recipeName, Item result, List<(string ingredient, bool playerHasIt)> ingredients) { }
+    /// <inheritdoc/>
+    public void ShowPrestigeInfo(PrestigeData prestige)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"⭐ Prestige Level: {prestige.PrestigeLevel}");
+        sb.AppendLine($"Victories: {prestige.TotalWins}");
+        sb.AppendLine($"Total Runs: {prestige.TotalRuns}");
+        sb.AppendLine();
+        
+        if (prestige.PrestigeLevel > 0)
+        {
+            sb.AppendLine("Active Bonuses:");
+            sb.AppendLine($"  +{prestige.PrestigeLevel * 2}% HP");
+            sb.AppendLine($"  +{prestige.PrestigeLevel}% ATK/DEF");
+            sb.AppendLine($"  +{prestige.PrestigeLevel * 50}g starting gold");
+        }
+        else
+        {
+            sb.Append("Complete a full run to unlock prestige bonuses!");
+        }
 
-    public void ShowMessage(string message) { }
-    public void ShowError(string message) { }
-    public void ShowHelp() { }
-    public void ShowCommandPrompt(Player? player = null) { }
-    public void ShowColoredMessage(string message, string color) { }
-    public void ShowColoredStat(string label, string value, string valueColor) { }
-    public void ShowLevelUpChoice(Player player) { }
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "⭐ Prestige"));
+    }
 
-    public void ShowVictory(Player player, int floorsCleared, RunStats stats) { }
-    public void ShowGameOver(Player player, string? killedBy, RunStats stats) { }
+    /// <inheritdoc/>
+    public void ShowFloorBanner(int floor, int maxFloor, DungeonVariant variant)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"════════════════════════════════");
+        sb.AppendLine($"   FLOOR {floor} OF {maxFloor}");
+        sb.AppendLine($"   {variant.Name}");
+        sb.AppendLine($"════════════════════════════════");
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString(), $"Floor {floor}"));
+    }
 
-    public void RefreshDisplay(Player player, Room room, int floor) { }
-    public void UpdateCooldownDisplay(IReadOnlyList<(string name, int turnsRemaining)> cooldowns) { }
+    /// <inheritdoc/>
+    public void ShowRoom(Room room)
+    {
+        bool isNewRoom = _cachedRoom?.Id != room.Id;
+        _cachedRoom = room;
+        _cachedCooldowns = [];
+        _cachedCombatEnemy = null;
+        _cachedEnemyEffects = Array.Empty<ActiveEffect>();
+
+        var sb = new StringBuilder();
+
+        // Room type prefix with decoration
+        var prefix = room.Type switch
+        {
+            RoomType.Dark             => "🌑 The room is pitch dark. ",
+            RoomType.Scorched         => "🔥 Scorch marks scar the stone. ",
+            RoomType.Flooded          => "💧 Ankle-deep water pools here. ",
+            RoomType.Mossy            => "🌿 Damp moss covers the walls. ",
+            RoomType.Ancient          => "🏛 Ancient runes line the walls. ",
+            RoomType.ForgottenShrine  => "✨ Holy light radiates from a forgotten shrine. ",
+            RoomType.PetrifiedLibrary => "📚 Petrified bookshelves line these ancient walls. ",
+            RoomType.ContestedArmory  => "⚔ Weapon racks gleam dangerously in the dark. ",
+            _                         => string.Empty
+        };
+
+        if (!string.IsNullOrEmpty(prefix))
+            sb.AppendLine(prefix);
+
+        sb.AppendLine(room.Description);
+
+        // Environmental hazard
+        var envLine = room.EnvironmentalHazard switch
+        {
+            RoomHazard.LavaSeam        => "🔥 Lava seams crack the floor — each action will burn you.",
+            RoomHazard.CorruptedGround => "💀 The ground pulses with dark energy — it will drain you.",
+            RoomHazard.BlessedClearing => "✨ A blessed warmth fills this clearing.",
+            _                          => null
+        };
+        if (envLine != null) sb.AppendLine(envLine);
+
+        // Hazard forewarning
+        var hazardLine = room.Type switch
+        {
+            RoomType.Scorched => "⚠ The scorched stone radiates heat — take care.",
+            RoomType.Flooded  => "⚠ The water here looks treacherous.",
+            RoomType.Dark     => "⚠ Darkness presses in around you.",
+            _                 => null
+        };
+        if (hazardLine != null) sb.AppendLine(hazardLine);
+
+        // Exits
+        if (room.Exits.Count > 0)
+        {
+            var exitSymbols = new Dictionary<Direction, string>
+            {
+                [Direction.North] = "↑ North",
+                [Direction.South] = "↓ South",
+                [Direction.East]  = "→ East",
+                [Direction.West]  = "← West"
+            };
+            var ordered = new[] { Direction.North, Direction.South, Direction.East, Direction.West }
+                .Where(d => room.Exits.ContainsKey(d))
+                .Select(d => exitSymbols[d]);
+            sb.AppendLine($"Exits: {string.Join("   ", ordered)}");
+        }
+
+        // Enemies
+        if (room.Enemy != null)
+            sb.AppendLine($"⚔ {room.Enemy.Name} is here!");
+
+        // Items on floor
+        if (room.Items.Count > 0)
+        {
+            sb.AppendLine("Items on the ground:");
+            foreach (var item in room.Items)
+                sb.AppendLine($"  ◆ {item.Name} ({PrimaryStatLabel(item)})");
+        }
+
+        // Special room hints
+        if (room.HasShrine && room.Type != RoomType.ForgottenShrine)
+            sb.AppendLine("✨ A shrine glimmers here. (USE SHRINE)");
+        if (room.Type == RoomType.ForgottenShrine && !room.SpecialRoomUsed)
+            sb.AppendLine("✨ A forgotten shrine stands here. (USE SHRINE)");
+        if (room.Type == RoomType.PetrifiedLibrary && !room.SpecialRoomUsed)
+            sb.AppendLine("📖 Ancient tomes line the walls. Something catches the light...");
+        if (room.Type == RoomType.ContestedArmory && !room.SpecialRoomUsed)
+            sb.AppendLine("⚠ Trapped weapons gleam in the dark. (USE ARMORY to approach)");
+        if (room.Merchant != null)
+            sb.AppendLine("🛒 A merchant awaits. (SHOP)");
+
+        var roomName = GetRoomDisplayName(room);
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.SetContent(sb.ToString().TrimEnd(), roomName);
+            _vm.Map.Update(room, _currentFloor);
+            if (_cachedPlayer != null)
+            {
+                _vm.Stats.Update(_cachedPlayer, _cachedCooldowns);
+                _vm.Gear.Update(_cachedPlayer);
+            }
+        });
+        
+        if (isNewRoom)
+            Dispatcher.UIThread.InvokeAsync(() => _vm.Log.AppendLog($"Entered {roomName}", "info"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowMap(Room currentRoom, int floor = 1)
+    {
+        _currentFloor = floor;
+        _cachedRoom = currentRoom;
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Map.Update(currentRoom, floor));
+    }
+
+    /// <inheritdoc/>
+    public void ShowCombat(string message)
+    {
+        var cleanMsg = StripAnsi(message);
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.Clear();
+            _vm.Content.SetContent($"═══ {cleanMsg} ═══", "⚔ Combat");
+            _vm.Log.AppendLog(cleanMsg, "combat");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowCombatStatus(Player player, Enemy enemy,
+        IReadOnlyList<ActiveEffect> playerEffects,
+        IReadOnlyList<ActiveEffect> enemyEffects)
+    {
+        _cachedPlayer = player;
+        _cachedCombatEnemy = enemy;
+        _cachedEnemyEffects = enemyEffects;
+
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Stats.UpdateCombat(player, _cachedCooldowns);
+            _vm.Gear.ShowEnemyStats(enemy, enemyEffects);
+        });
+
+        // Low HP warning
+        if (player.MaxHP > 0)
+        {
+            bool isLowHp = player.HP < player.MaxHP * 0.30;
+            if (isLowHp && !_lowHpWarningIssued)
+            {
+                _lowHpWarningIssued = true;
+                Dispatcher.UIThread.InvokeAsync(() => _vm.Log.AppendLog($"Low HP! {player.HP}/{player.MaxHP} — below 30%!", "combat"));
+            }
+            else if (!isLowHp)
+            {
+                _lowHpWarningIssued = false;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void ShowCombatMessage(string message)
+    {
+        var cleanMsg = StripAnsi(message);
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.AppendMessage($"  {cleanMsg}");
+            _vm.Log.AppendLog(cleanMsg, "combat");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowColoredCombatMessage(string message, string color)
+    {
+        // For plain text, ignore color
+        ShowCombatMessage(message);
+    }
+
+    /// <inheritdoc/>
+    public void ShowCombatStart(Enemy enemy)
+    {
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.Clear();
+            _vm.Content.AppendMessage("⚔ ─── COMBAT ─── ⚔");
+            _vm.Content.AppendMessage($"{enemy.Name}");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowCombatEntryFlags(Enemy enemy)
+    {
+        if (enemy.IsElite)
+            Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage("⭐ ELITE ENEMY"));
+        if (enemy is Dungnz.Systems.Enemies.DungeonBoss boss && boss.IsEnraged)
+            Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage("⚡ ENRAGED!"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowEnemyArt(Enemy enemy)
+    {
+        if (enemy.AsciiArt == null || enemy.AsciiArt.Length == 0)
+            return;
+        var art = string.Join("\n", enemy.AsciiArt);
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage(art));
+    }
+
+    /// <inheritdoc/>
+    public void ShowEnemyDetail(Enemy enemy)
+    {
+        var hpBar = BuildPlainHpBar(enemy.HP, enemy.MaxHP, 12);
+        var sb = new StringBuilder();
+        sb.AppendLine($"HP {hpBar} {enemy.HP}/{enemy.MaxHP}");
+        sb.AppendLine($"ATK {enemy.Attack}  DEF {enemy.Defense}");
+        sb.AppendLine($"XP {enemy.XPValue}");
+        if (enemy.IsElite)
+            sb.Append("⭐ Elite");
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage(sb.ToString().TrimEnd()));
+    }
+
+    /// <inheritdoc/>
+    public void ShowCombatHistory()
+    {
+        // Log panel already shows scrollback — just notify user
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage("Combat history is displayed in the Log panel."));
+    }
+
+    /// <inheritdoc/>
+    public void ShowPlayerStats(Player player)
+    {
+        _cachedPlayer = player;
+        
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (_cachedCombatEnemy != null)
+            {
+                // In combat: update both stats and enemy panels
+                _vm.Stats.UpdateCombat(player, _cachedCooldowns);
+                _vm.Gear.ShowEnemyStats(_cachedCombatEnemy, _cachedEnemyEffects);
+            }
+            else
+            {
+                _vm.Stats.Update(player, _cachedCooldowns);
+                _vm.Gear.Update(player);
+            }
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowInventory(Player player)
+    {
+        var sb = new StringBuilder();
+        int currentWeight = player.Inventory.Sum(i => i.Weight);
+        int maxWeight     = InventoryManager.MaxWeight;
+        
+        sb.AppendLine($"Slots: {player.Inventory.Count}/{Player.MaxInventorySize}  │  Weight: {currentWeight}/{maxWeight}");
+        sb.AppendLine();
+
+        if (player.Inventory.Count == 0)
+        {
+            sb.AppendLine("  (inventory empty)");
+        }
+        else
+        {
+            int idx = 1;
+            foreach (var group in player.Inventory.GroupBy(i => i.Name))
+            {
+                var item     = group.First();
+                var count    = group.Count();
+                var countStr = count > 1 ? $" ×{count}" : "";
+                sb.AppendLine($"  {idx,2}. {ItemIcon(item)} {item.Name}{countStr}  {PrimaryStatLabel(item)}");
+                idx++;
+            }
+        }
+
+        sb.AppendLine();
+        sb.Append($"💰 {player.Gold}g");
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "🎒 Inventory"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowEquipment(Player player)
+    {
+        var sb = new StringBuilder();
+
+        void AddSlot(string slotLabel, Item? item)
+        {
+            if (item == null)
+            {
+                sb.AppendLine($"{slotLabel}:  (empty)");
+                return;
+            }
+            sb.AppendLine($"{slotLabel}:  {item.Name}  {PrimaryStatLabel(item)}");
+        }
+
+        AddSlot("⚔  Weapon",    player.EquippedWeapon);
+        AddSlot("💍 Accessory", player.EquippedAccessory);
+        AddSlot("🪖 Head",      player.EquippedHead);
+        AddSlot("🥋 Shoulders", player.EquippedShoulders);
+        AddSlot("🦺 Chest",     player.EquippedChest);
+        AddSlot("🧤 Hands",     player.EquippedHands);
+        AddSlot("👖 Legs",      player.EquippedLegs);
+        AddSlot("👟 Feet",      player.EquippedFeet);
+        AddSlot("🧥 Back",      player.EquippedBack);
+        AddSlot("🔰 Off-Hand",  player.EquippedOffHand);
+
+        var setDesc = SetBonusManager.GetActiveBonusDescription(player);
+        if (!string.IsNullOrEmpty(setDesc))
+        {
+            sb.AppendLine();
+            sb.Append($"Set Bonus: {setDesc}");
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "⚔ Equipment"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowEquipmentComparison(Player player, Item? oldItem, Item newItem)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"New: {ItemIcon(newItem)} {newItem.Name}");
+        sb.AppendLine($"     {PrimaryStatLabel(newItem)}");
+        
+        if (oldItem != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Old: {ItemIcon(oldItem)} {oldItem.Name}");
+            sb.AppendLine($"     {PrimaryStatLabel(oldItem)}");
+            sb.AppendLine();
+            
+            var atkDelta  = newItem.AttackBonus  - oldItem.AttackBonus;
+            var defDelta  = newItem.DefenseBonus - oldItem.DefenseBonus;
+            var manaDelta = newItem.MaxManaBonus - oldItem.MaxManaBonus;
+            
+            if (atkDelta != 0)  sb.AppendLine($"ATK:  {FormatDelta(atkDelta)}");
+            if (defDelta != 0)  sb.AppendLine($"DEF:  {FormatDelta(defDelta)}");
+            if (manaDelta != 0) sb.AppendLine($"Mana: {FormatDelta(manaDelta)}");
+        }
+        else
+        {
+            sb.AppendLine();
+            sb.Append("New slot — nothing equipped");
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "⚖ Comparison"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowItemDetail(Item item)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Type:    {item.Type}");
+        sb.AppendLine($"Tier:    {item.Tier}");
+        sb.AppendLine($"Weight:  {item.Weight}");
+        if (item.AttackBonus  != 0) sb.AppendLine($"Attack:  +{item.AttackBonus}");
+        if (item.DefenseBonus != 0) sb.AppendLine($"Defense: +{item.DefenseBonus}");
+        if (item.HealAmount   != 0) sb.AppendLine($"Heal:    +{item.HealAmount} HP");
+        if (item.ManaRestore  != 0) sb.AppendLine($"Mana:    +{item.ManaRestore}");
+        if (item.MaxManaBonus != 0) sb.AppendLine($"Max Mana:+{item.MaxManaBonus}");
+        if (item.DodgeBonus   >  0) sb.AppendLine($"Dodge:   +{item.DodgeBonus:P0}");
+        if (item.CritChance   >  0) sb.AppendLine($"Crit:    +{item.CritChance:P0}");
+        if (!string.IsNullOrEmpty(item.Description))
+        {
+            sb.AppendLine();
+            sb.Append(item.Description);
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), $"{ItemIcon(item)} {item.Name}"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowLootDrop(Item item, Player player, bool isElite = false)
+    {
+        var header = isElite ? "✦ ELITE LOOT DROP" : "✦ LOOT DROP";
+        var stat   = PrimaryStatLabel(item);
+
+        var sb = new StringBuilder();
+        sb.AppendLine(header);
+        sb.AppendLine($"{item.Tier}");
+        sb.AppendLine($"{ItemIcon(item)} {item.Name}");
+        sb.AppendLine($"{stat}  {item.Weight} wt");
+
+        var equipped = GetEquippedInSameSlot(item, player);
+        if (equipped != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"vs {equipped.Name}");
+            
+            var atkDelta  = item.AttackBonus  - equipped.AttackBonus;
+            var defDelta  = item.DefenseBonus - equipped.DefenseBonus;
+            
+            if (atkDelta != 0) sb.AppendLine($"  ATK: {FormatDelta(atkDelta)}");
+            if (defDelta != 0) sb.AppendLine($"  DEF: {FormatDelta(defDelta)}");
+        }
+        else if (item.IsEquippable)
+        {
+            sb.AppendLine();
+            sb.Append("New slot — nothing equipped");
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.SetContent(sb.ToString().TrimEnd(), "💰 Loot");
+            _vm.Log.AppendLog($"Loot: {item.Name}", "loot");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowGoldPickup(int amount, int newTotal)
+    {
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.SetContent($"💰 +{amount} gold  (Total: {newTotal}g)", "💰 Gold");
+            _vm.Log.AppendLog($"+{amount} gold (total: {newTotal}g)", "loot");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowItemPickup(Item item, int slotsCurrent, int slotsMax, int weightCurrent, int weightMax)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"{ItemIcon(item)} Picked up: {item.Name}");
+        sb.AppendLine($"{PrimaryStatLabel(item)}");
+        sb.AppendLine($"Slots: {slotsCurrent}/{slotsMax}  ·  Weight: {weightCurrent}/{weightMax}");
+        if (weightCurrent > weightMax * 0.8)
+            sb.Append("⚠ Inventory nearly full!");
+
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.SetContent(sb.ToString().TrimEnd(), "📦 Pickup");
+            _vm.Log.AppendLog($"Picked up: {item.Name}", "loot");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowShop(IEnumerable<(Item item, int price)> stock, int playerGold)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Your gold: {playerGold}g");
+        sb.AppendLine();
+
+        int idx = 1;
+        foreach (var (item, price) in stock)
+        {
+            var afford = playerGold >= price ? "  " : "✗ ";
+            sb.AppendLine($"  {idx,2}. {afford}{ItemIcon(item)} {item.Name} — {item.Tier} — {PrimaryStatLabel(item)} — {price}g");
+            idx++;
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "🛒 Merchant"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowSellMenu(IEnumerable<(Item item, int sellPrice)> items, int playerGold)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Your gold: {playerGold}g");
+        sb.AppendLine();
+
+        int idx = 1;
+        foreach (var (item, sellPrice) in items)
+        {
+            sb.AppendLine($"  {idx,2}. {ItemIcon(item)} {item.Name} — {PrimaryStatLabel(item)} — {sellPrice}g");
+            idx++;
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "💰 Sell Items"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowCraftRecipe(string recipeName, Item result, List<(string ingredient, bool playerHasIt)> ingredients)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Recipe: {recipeName}");
+        sb.AppendLine($"Result: {ItemIcon(result)} {result.Name}");
+        sb.AppendLine($"Stats:  {PrimaryStatLabel(result)}");
+        sb.AppendLine();
+        sb.AppendLine("Ingredients:");
+        
+        foreach (var (ingredient, hasIt) in ingredients)
+        {
+            var mark = hasIt ? "✓" : "✗";
+            sb.AppendLine($"  {mark} {ingredient}");
+        }
+
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "⚗ Crafting"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowMessage(string message)
+    {
+        var cleanMsg = StripAnsi(message);
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.AppendMessage(cleanMsg);
+            _vm.Log.AppendLog(cleanMsg, "info");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowError(string message)
+    {
+        var cleanMsg = StripAnsi(message);
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.AppendMessage($"✗ {cleanMsg}");
+            _vm.Log.AppendLog(cleanMsg, "error");
+        });
+    }
+
+    /// <inheritdoc/>
+    public void ShowHelp()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("── Navigation ──");
+        sb.AppendLine("go [n|s|e|w]  Move   │  look  Redescribe   │  map  Mini-map");
+        sb.AppendLine("descend  Descend to the next floor   │  ascend  Return to previous floor");
+        sb.AppendLine("return   Fast-travel to the floor entrance   │  back  Step back one room");
+        sb.AppendLine();
+        sb.AppendLine("── Items ──");
+        sb.AppendLine("take [item]   use [item]   equip [item]   examine [target]");
+        sb.AppendLine("inventory   equipment   craft [recipe]   shop   sell");
+        sb.AppendLine();
+        sb.AppendLine("── Character ──");
+        sb.AppendLine("stats   skills   learn [skill]");
+        sb.AppendLine();
+        sb.AppendLine("── Systems ──");
+        sb.AppendLine("save [name]   load [name]   listsaves");
+        sb.AppendLine("prestige   leaderboard   help   quit");
+        sb.AppendLine();
+        sb.AppendLine("── Log ──");
+        sb.Append("history   Show full combat log scrollback in this panel");
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "❓ Help"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowCommandPrompt(Player? player = null)
+    {
+        // Input panel wiring deferred to P5
+    }
+
+    /// <inheritdoc/>
+    public void ShowColoredMessage(string message, string color)
+    {
+        // For plain text, ignore color
+        ShowMessage(message);
+    }
+
+    /// <inheritdoc/>
+    public void ShowColoredStat(string label, string value, string valueColor)
+    {
+        var cleanLabel = StripAnsi(label);
+        var cleanValue = StripAnsi(value);
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage($"{cleanLabel,-8} {cleanValue}"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowLevelUpChoice(Player player)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"🎉 LEVEL UP! Now level {player.Level}");
+        sb.AppendLine();
+        sb.AppendLine("Choose your stat boost:");
+        sb.AppendLine("  1. +10 HP");
+        sb.AppendLine("  2. +2 ATK");
+        sb.Append("  3. +2 DEF");
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString(), "⭐ Level Up"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowVictory(Player player, int floorsCleared, RunStats stats)
+    {
+        var floorWord = floorsCleared == 1 ? "floor" : "floors";
+        var sb = new StringBuilder();
+        sb.AppendLine("✦  V I C T O R Y  ✦");
+        sb.AppendLine();
+        sb.AppendLine($"{player.Name}  •  Level {player.Level}  •  {player.Class}");
+        sb.AppendLine($"{floorsCleared} {floorWord} conquered");
+        sb.AppendLine();
+        sb.AppendLine($"Enemies slain:  {stats.EnemiesDefeated}");
+        sb.AppendLine($"Gold earned:    {stats.GoldCollected}");
+        sb.AppendLine($"Items found:    {stats.ItemsFound}");
+        sb.Append($"Turns taken:    {stats.TurnsTaken}");
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "🏆 Victory!"));
+    }
+
+    /// <inheritdoc/>
+    public void ShowGameOver(Player player, string? killedBy, RunStats stats)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("☠  RUN ENDED  ☠");
+        sb.AppendLine();
+        sb.AppendLine($"{player.Name}  •  Level {player.Level}  •  {player.Class}");
+        if (!string.IsNullOrEmpty(killedBy))
+            sb.AppendLine($"Killed by: {killedBy}");
+        sb.AppendLine();
+        sb.AppendLine($"Enemies slain:  {stats.EnemiesDefeated}");
+        sb.AppendLine($"Floors reached: {stats.FloorsVisited}");
+        sb.AppendLine($"Gold earned:    {stats.GoldCollected}");
+        sb.AppendLine($"Items found:    {stats.ItemsFound}");
+        sb.Append($"Turns taken:    {stats.TurnsTaken}");
+        
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.SetContent(sb.ToString().TrimEnd(), "☠ Game Over"));
+    }
+
+    /// <inheritdoc/>
+    public void RefreshDisplay(Player player, Room room, int floor)
+    {
+        _currentFloor = floor;
+        _cachedPlayer = player;
+        _cachedRoom = room;
+        
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Stats.Update(player, _cachedCooldowns);
+            _vm.Map.Update(room, floor);
+            _vm.Gear.Update(player);
+        });
+        
+        ShowRoom(room);
+    }
+
+    /// <inheritdoc/>
+    public void UpdateCooldownDisplay(IReadOnlyList<(string name, int turnsRemaining)> cooldowns)
+    {
+        _cachedCooldowns = cooldowns;
+        if (_cachedPlayer != null)
+        {
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (_cachedCombatEnemy != null)
+                    _vm.Stats.UpdateCombat(_cachedPlayer, cooldowns);
+                else
+                    _vm.Stats.Update(_cachedPlayer, cooldowns);
+            });
+        }
+    }
 
     // ══════════════════════════════════════════════════════════════════════════
     // IGameInput Implementation (Input-coupled methods)
     // ══════════════════════════════════════════════════════════════════════════
 
-    // TODO: P3-P8 implementation
+    // TODO: P5-P8 implementation
     public string? ReadCommandInput() => null;
     public string ReadPlayerName() => "Player";
     public int? ReadSeed() => null;
@@ -97,4 +780,91 @@ public class AvaloniaDisplayService : IDisplayService
     public int ShowContestedArmoryMenuAndSelect(int playerDefense) => 0;
 
     public Skill? ShowSkillTreeMenu(Player player) => null;
+
+    // ── Private static helpers ────────────────────────────────────────────────
+
+    private static string StripAnsi(string text) =>
+        Regex.Replace(text, @"\x1b\[[0-9;]*m", "");
+
+    private static string BuildPlainHpBar(int current, int max, int width = 10)
+    {
+        if (max <= 0) return new string('░', width);
+        current = Math.Clamp(current, 0, max);
+        int filled = (int)Math.Round((double)current / max * width);
+        return new string('█', filled) + new string('░', width - filled);
+    }
+
+    private static string ItemTypeIcon(ItemType type) => type switch
+    {
+        ItemType.Weapon           => "⚔",
+        ItemType.Armor            => "🦺",
+        ItemType.Consumable       => "🧪",
+        ItemType.Accessory        => "💍",
+        ItemType.CraftingMaterial => "⚗",
+        _                         => "•"
+    };
+
+    private static string SlotIcon(ArmorSlot slot) => slot switch
+    {
+        ArmorSlot.Head      => "🪖",
+        ArmorSlot.Shoulders => "🥋",
+        ArmorSlot.Chest     => "🦺",
+        ArmorSlot.Hands     => "🧤",
+        ArmorSlot.Legs      => "👖",
+        ArmorSlot.Feet      => "👟",
+        ArmorSlot.Back      => "🧥",
+        ArmorSlot.OffHand   => "🔰",
+        _                   => "🦺",
+    };
+
+    private static string ItemIcon(Item item) =>
+        item.Type == ItemType.Armor ? SlotIcon(item.Slot) : ItemTypeIcon(item.Type);
+
+    private static string PrimaryStatLabel(Item item)
+    {
+        if (item.AttackBonus  != 0) return $"Attack +{item.AttackBonus}";
+        if (item.DefenseBonus != 0) return $"Defense +{item.DefenseBonus}";
+        if (item.HealAmount   != 0) return $"Heals {item.HealAmount} HP";
+        if (item.ManaRestore  != 0) return $"Mana +{item.ManaRestore}";
+        if (item.MaxManaBonus != 0) return $"Max Mana +{item.MaxManaBonus}";
+        return item.Type.ToString();
+    }
+
+    private static string GetRoomDisplayName(Room room) => room.Type switch
+    {
+        RoomType.Standard         => "Dungeon Room",
+        RoomType.Dark             => "Dark Chamber",
+        RoomType.Scorched         => "Scorched Hall",
+        RoomType.Flooded          => "Flooded Passage",
+        RoomType.Mossy            => "Mossy Alcove",
+        RoomType.Ancient          => "Ancient Hall",
+        RoomType.ForgottenShrine  => "Forgotten Shrine",
+        RoomType.PetrifiedLibrary => "Petrified Library",
+        RoomType.ContestedArmory  => "Contested Armory",
+        RoomType.TrapRoom         => "Trap Room",
+        _                         => "Dungeon Room",
+    };
+
+    private static Item? GetEquippedInSameSlot(Item candidate, Player player) =>
+        candidate.Type switch
+        {
+            ItemType.Weapon    => player.EquippedWeapon,
+            ItemType.Accessory => player.EquippedAccessory,
+            ItemType.Armor     => candidate.Slot switch
+            {
+                ArmorSlot.Head      => player.EquippedHead,
+                ArmorSlot.Shoulders => player.EquippedShoulders,
+                ArmorSlot.Chest     => player.EquippedChest,
+                ArmorSlot.Hands     => player.EquippedHands,
+                ArmorSlot.Legs      => player.EquippedLegs,
+                ArmorSlot.Feet      => player.EquippedFeet,
+                ArmorSlot.Back      => player.EquippedBack,
+                ArmorSlot.OffHand   => player.EquippedOffHand,
+                _                   => player.EquippedChest,
+            },
+            _ => null,
+        };
+
+    private static string FormatDelta(int delta) =>
+        delta > 0 ? $"+{delta}" : delta.ToString();
 }

--- a/Dungnz.Display.Avalonia/ViewModels/ContentPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/ContentPanelViewModel.cs
@@ -14,9 +14,37 @@ public partial class ContentPanelViewModel : ObservableObject
     [ObservableProperty]
     private string _headerText = "Adventure";
 
-    // TODO: P3-P8 implementation
+    private const int MaxContentLines = 50;
+
+    /// <summary>
+    /// Appends a message to the content panel buffer.
+    /// </summary>
     public void AppendMessage(string message)
     {
         ContentLines.Add(message);
+        if (ContentLines.Count > MaxContentLines)
+            ContentLines.RemoveAt(0);
+    }
+
+    /// <summary>
+    /// Replaces the content panel with new content.
+    /// </summary>
+    public void SetContent(string content, string header)
+    {
+        ContentLines.Clear();
+        HeaderText = header;
+        if (!string.IsNullOrEmpty(content))
+        {
+            foreach (var line in content.Split('\n'))
+                ContentLines.Add(line);
+        }
+    }
+
+    /// <summary>
+    /// Clears all content lines.
+    /// </summary>
+    public void Clear()
+    {
+        ContentLines.Clear();
     }
 }

--- a/Dungnz.Display.Avalonia/ViewModels/GearPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/GearPanelViewModel.cs
@@ -1,4 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Dungnz.Models;
+using Dungnz.Systems;
+using System.Text;
 
 namespace Dungnz.Display.Avalonia.ViewModels;
 
@@ -9,4 +12,158 @@ public partial class GearPanelViewModel : ObservableObject
 {
     [ObservableProperty]
     private string _gearText = "Gear will appear here";
+
+    /// <summary>
+    /// Updates the gear panel with player's equipped items.
+    /// </summary>
+    public void Update(Player player)
+    {
+        GearText = BuildGearText(player);
+    }
+
+    /// <summary>
+    /// Shows enemy stats in the gear panel during combat.
+    /// </summary>
+    public void ShowEnemyStats(Enemy enemy, IReadOnlyList<ActiveEffect> enemyEffects)
+    {
+        GearText = BuildEnemyStatsText(enemy, enemyEffects);
+    }
+
+    private static string BuildGearText(Player player)
+    {
+        var sb = new StringBuilder();
+
+        void AddSlot(string slotLabel, Item? item, bool isWeapon = false, bool isAccessory = false)
+        {
+            if (item == null)
+            {
+                sb.AppendLine($"{slotLabel}:  (empty)");
+                return;
+            }
+            var statParts = new List<string>();
+            if (isWeapon)
+            {
+                if (item.AttackBonus  != 0) statParts.Add($"+{item.AttackBonus} ATK");
+                if (item.DodgeBonus   >  0) statParts.Add($"+{item.DodgeBonus:P0} dodge");
+                if (item.MaxManaBonus >  0) statParts.Add($"+{item.MaxManaBonus} mana");
+            }
+            else if (isAccessory)
+            {
+                if (item.AttackBonus  != 0) statParts.Add($"+{item.AttackBonus} ATK");
+                if (item.DefenseBonus != 0) statParts.Add($"+{item.DefenseBonus} DEF");
+                if (item.StatModifier != 0) statParts.Add($"+{item.StatModifier} HP");
+                if (item.DodgeBonus   >  0) statParts.Add($"+{item.DodgeBonus:P0} dodge");
+            }
+            else
+            {
+                if (item.DefenseBonus != 0) statParts.Add($"+{item.DefenseBonus} DEF");
+                if (item.DodgeBonus   >  0) statParts.Add($"+{item.DodgeBonus:P0} dodge");
+                if (item.MaxManaBonus >  0) statParts.Add($"+{item.MaxManaBonus} mana");
+            }
+            var statsStr = statParts.Count > 0 ? "  " + string.Join(", ", statParts) : "";
+            sb.AppendLine($"{slotLabel}:  {item.Name}{statsStr}");
+        }
+
+        AddSlot("⚔  Weapon",    player.EquippedWeapon,    isWeapon: true);
+        AddSlot("💍 Accessory", player.EquippedAccessory, isAccessory: true);
+        AddSlot("🪖 Head",      player.EquippedHead);
+        AddSlot("🥋 Shoulders", player.EquippedShoulders);
+        AddSlot("🦺 Chest",     player.EquippedChest);
+        AddSlot("🧤 Hands",     player.EquippedHands);
+        AddSlot("👖 Legs",      player.EquippedLegs);
+        AddSlot("👟 Feet",      player.EquippedFeet);
+        AddSlot("🧥 Back",      player.EquippedBack);
+        AddSlot("🔰 Off-Hand",  player.EquippedOffHand);
+
+        var setDesc = SetBonusManager.GetActiveBonusDescription(player);
+        if (!string.IsNullOrEmpty(setDesc))
+        {
+            sb.AppendLine();
+            sb.Append($"Set Bonus: {setDesc}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string BuildEnemyStatsText(Enemy enemy, IReadOnlyList<ActiveEffect> enemyEffects)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"🐉 {enemy.Name}");
+
+        if (enemy is Dungnz.Systems.Enemies.DungeonBoss boss)
+        {
+            var phaseNum = boss.FiredPhases.Count + 1;
+            sb.Append($"Phase {phaseNum}");
+            if (boss.IsEnraged)
+                sb.Append($"  ⚡ ENRAGED");
+            sb.AppendLine();
+        }
+
+        var hpBar = BuildPlainHpBar(enemy.HP, enemy.MaxHP);
+        sb.AppendLine($"HP {hpBar} {enemy.HP}/{enemy.MaxHP}");
+        sb.AppendLine($"ATK {enemy.Attack}  DEF {enemy.Defense}");
+
+        var regenParts = new List<string>();
+        if (enemy.RegenPerTurn > 0)
+            regenParts.Add($"Regen +{enemy.RegenPerTurn}/turn");
+        if (enemy.SelfHealAmount > 0 && enemy.SelfHealEveryTurns > 0)
+            regenParts.Add($"Heals +{enemy.SelfHealAmount} every {enemy.SelfHealEveryTurns}t");
+        if (regenParts.Count > 0)
+        {
+            sb.Append(string.Join("  ", regenParts));
+            sb.AppendLine();
+        }
+
+        var badges = new List<string>();
+        if (enemy.IsElite)                  badges.Add("⭐ Elite");
+        if (enemy.IsUndead)                 badges.Add("💀 Undead");
+        if (enemy.IsStunImmune)             badges.Add("🛡 StunImm");
+        if (enemy.IsImmuneToEffects)        badges.Add("🔒 EffectImm");
+        if (enemy.LifestealPercent > 0)     badges.Add("🩸 Lifesteal");
+        if (enemy.AppliesPoisonOnHit)       badges.Add("☠ Poison");
+        if (enemy.CounterStrikeChance > 0)  badges.Add("↩ Counter");
+        if (enemy.PackCount > 1)            badges.Add($"🐾 Pack×{enemy.PackCount}");
+        if (badges.Count > 0)
+        {
+            sb.Append(string.Join(" ", badges));
+            sb.AppendLine();
+        }
+
+        if (enemyEffects.Count > 0)
+        {
+            foreach (var e in enemyEffects)
+            {
+                sb.Append($"[{EffectIcon(e.Effect)}{e.Effect} {e.RemainingTurns}t] ");
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string BuildPlainHpBar(int current, int max, int width = 10)
+    {
+        if (max <= 0) return new string('░', width);
+        current = Math.Clamp(current, 0, max);
+        int filled = (int)Math.Round((double)current / max * width);
+        return new string('█', filled) + new string('░', width - filled);
+    }
+
+    private static string EffectIcon(StatusEffect effect) => effect switch
+    {
+        StatusEffect.Poison    => "☠",
+        StatusEffect.Bleed     => "🩸",
+        StatusEffect.Stun      => "⚡",
+        StatusEffect.Regen     => "✨",
+        StatusEffect.Fortified => "🛡",
+        StatusEffect.Weakened  => "💀",
+        StatusEffect.Slow      => ">",
+        StatusEffect.BattleCry => "!",
+        StatusEffect.Burn      => "*",
+        StatusEffect.Freeze    => "~",
+        StatusEffect.Silence   => "X",
+        StatusEffect.Curse     => "@",
+        _                      => "●"
+    };
 }

--- a/Dungnz.Display.Avalonia/ViewModels/LogPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/LogPanelViewModel.cs
@@ -10,4 +10,53 @@ public partial class LogPanelViewModel : ObservableObject
 {
     [ObservableProperty]
     private ObservableCollection<string> _logLines = new();
+
+    private readonly List<string> _logHistory = new();
+    private const int MaxLogHistory = 50;
+    private const int MaxDisplayedLog = 12;
+
+    /// <summary>
+    /// Appends a log entry with timestamp and type classification.
+    /// </summary>
+    public void AppendLog(string message, string type = "info")
+    {
+        var timestamp = DateTime.Now.ToString("HH:mm");
+        string icon;
+
+        if (type == "combat")
+        {
+            icon = ClassifyCombatLogIcon(message);
+        }
+        else
+        {
+            icon = type switch
+            {
+                "error" => "❌",
+                "loot"  => "💰",
+                _       => "ℹ"
+            };
+        }
+
+        _logHistory.Add($"{timestamp} {icon} {message}");
+        if (_logHistory.Count > MaxLogHistory)
+            _logHistory.RemoveAt(0);
+
+        UpdateDisplay();
+    }
+
+    private void UpdateDisplay()
+    {
+        LogLines.Clear();
+        foreach (var line in _logHistory.TakeLast(MaxDisplayedLog))
+        {
+            LogLines.Add(line);
+        }
+    }
+
+    private static string ClassifyCombatLogIcon(string message) =>
+        message.Contains("Critical", StringComparison.OrdinalIgnoreCase) ? "💥" :
+        message.Contains("Healed", StringComparison.OrdinalIgnoreCase) ? "💚" :
+        message.Contains("Poison", StringComparison.OrdinalIgnoreCase) ? "☠" :
+        message.Contains("Burn", StringComparison.OrdinalIgnoreCase) ? "🔥" :
+        "⚔";
 }

--- a/Dungnz.Display.Avalonia/ViewModels/MapPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/MapPanelViewModel.cs
@@ -1,4 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Dungnz.Display;
+using Dungnz.Models;
 
 namespace Dungnz.Display.Avalonia.ViewModels;
 
@@ -9,4 +11,16 @@ public partial class MapPanelViewModel : ObservableObject
 {
     [ObservableProperty]
     private string _mapText = "Map will appear here";
+
+    [ObservableProperty]
+    private int _currentFloor = 1;
+
+    /// <summary>
+    /// Updates the map panel with the current room and floor.
+    /// </summary>
+    public void Update(Room currentRoom, int floor)
+    {
+        CurrentFloor = floor;
+        MapText = MapRenderer.BuildPlainTextMap(currentRoom, floor);
+    }
 }

--- a/Dungnz.Display.Avalonia/ViewModels/StatsPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/StatsPanelViewModel.cs
@@ -1,4 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Dungnz.Models;
+using System.Text;
 
 namespace Dungnz.Display.Avalonia.ViewModels;
 
@@ -9,4 +11,91 @@ public partial class StatsPanelViewModel : ObservableObject
 {
     [ObservableProperty]
     private string _statsText = "Stats will appear here";
+
+    /// <summary>
+    /// Updates the stats panel with player stats in exploration mode.
+    /// </summary>
+    public void Update(Player player, IReadOnlyList<(string name, int turnsRemaining)> cooldowns)
+    {
+        StatsText = BuildPlayerStatsText(player, cooldowns);
+    }
+
+    /// <summary>
+    /// Updates the stats panel with player stats in combat mode.
+    /// Enemy stats are displayed separately in the Gear panel.
+    /// </summary>
+    public void UpdateCombat(Player player, IReadOnlyList<(string name, int turnsRemaining)> cooldowns)
+    {
+        StatsText = BuildPlayerStatsText(player, cooldowns);
+    }
+
+    private static string BuildPlayerStatsText(Player player, IReadOnlyList<(string name, int turnsRemaining)> cooldowns)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"{player.Name}  Lv {player.Level}  {player.Class}");
+        sb.AppendLine();
+
+        var hpBar = BuildPlainHpBar(player.HP, player.MaxHP);
+        sb.AppendLine($"HP {hpBar} {player.HP}/{player.MaxHP}");
+
+        if (player.MaxMana > 0)
+        {
+            var mpBar = BuildPlainMpBar(player.Mana, player.MaxMana);
+            sb.AppendLine($"MP {mpBar} {player.Mana}/{player.MaxMana}");
+        }
+
+        if (cooldowns.Count > 0)
+        {
+            var cdParts = cooldowns.Select(c =>
+                c.turnsRemaining == 0
+                    ? $"{c.name}:✅"
+                    : $"{c.name}:{c.turnsRemaining}t");
+            sb.AppendLine($"CD: {string.Join("  ", cdParts)}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"ATK {player.Attack}   DEF {player.Defense}");
+        sb.AppendLine($"Gold {player.Gold}g");
+        var xpToNext = 100 * player.Level;
+        sb.AppendLine($"XP {player.XP}/{xpToNext}");
+
+        if (player.Class == PlayerClass.Rogue && player.ComboPoints > 0)
+        {
+            var dots = new string('●', player.ComboPoints) + new string('○', 5 - player.ComboPoints);
+            sb.AppendLine($"❖ Combo {dots}");
+        }
+
+        if (player.Momentum is { } momentum)
+        {
+            var label = player.Class switch
+            {
+                PlayerClass.Warrior => "Fury",
+                PlayerClass.Mage    => "Charge",
+                PlayerClass.Paladin => "Devotion",
+                PlayerClass.Ranger  => "Focus",
+                _                   => "Momentum"
+            };
+            var dots = new string('●', momentum.Current) + new string('○', momentum.Maximum - momentum.Current);
+            var chargedSuffix = momentum.IsCharged ? " [CHARGED]" : string.Empty;
+            sb.AppendLine($"❖ {label} {dots}{chargedSuffix}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string BuildPlainHpBar(int current, int max, int width = 10)
+    {
+        if (max <= 0) return new string('░', width);
+        current = Math.Clamp(current, 0, max);
+        int filled = (int)Math.Round((double)current / max * width);
+        return new string('█', filled) + new string('░', width - filled);
+    }
+
+    private static string BuildPlainMpBar(int current, int max, int width = 10)
+    {
+        if (max <= 0) return string.Empty;
+        current = Math.Clamp(current, 0, max);
+        int filled = (int)Math.Round((double)current / max * width);
+        return new string('█', filled) + new string('░', width - filled);
+    }
 }


### PR DESCRIPTION
Implements all 31 IGameDisplay output methods in AvaloniaDisplayService.

Closes the P3 milestone of the Avalonia migration.

## Changes
- **AvaloniaDisplayService**: all output methods implemented with `Dispatcher.UIThread.InvokeAsync` pattern
- **ViewModels**: Stats, Gear, Content, Log, Map expanded with proper Update methods
- **App.axaml.cs**: wire MainWindowViewModel to AvaloniaDisplayService constructor
- **Plain text rendering**: No Spectre markup, HP bars, item icons, combat log classification

## Architecture
- **Thread model**: All output methods fire-and-forget from game thread to UI thread
- **Cached state**: Player, Room, Floor, CombatEnemy, EnemyEffects, Cooldowns, LowHpWarning
- **Combat mode**: Stats panel shows player, Gear panel shows enemy (mirrors Spectre pattern)
- **Room exit**: Clears combat enemy cache, restores Gear panel to player equipment

## Testing
- `dotnet build Dungnz.slnx` passes (0 errors)
- `dotnet test` passes (2,154 tests)
- `dotnet build Dungnz.Display.Avalonia/` passes independently

## Next Steps
P4: Map panel polish (deferred — basic map already wired)
P5: Input panel and ReadCommandInput
P6-P8: All IGameInput menu methods