### PR TITLE
[Scribe] Merge P5 decision + session log

### DIFF
--- a/.ai-team/agents/hill/history.md
+++ b/.ai-team/agents/hill/history.md
@@ -2221,3 +2221,4 @@ ReadCommandInput() unblocks ←────────
 
 **P6:** Menu implementations — selection prompts for difficulty, class, combat, inventory, shop menus. Will use overlay dialogs or in-panel selection lists.
 **P7-P8:** Remaining IGameInput stubs (shrine menus, skill tree, confirm dialogs, etc.).
+- 2025-07-17: Avalonia P5 — TCS-Based Input Bridge (see decisions.md)

--- a/.ai-team/agents/scribe/history.md
+++ b/.ai-team/agents/scribe/history.md
@@ -8,5 +8,7 @@
 ## Activity
 
 - 2025-01-12: Merged inbox decision "Avalonia P3 Output Panel Architecture" into decisions.md (author: Hill, PR #1403)
+- 2025-07-17: Merged inbox decision "Avalonia P5 — TCS-Based Input Bridge" into decisions.md (author: Hill, PR #1405)
+- 2025-07-17: Logged session 2025-07-17-avalonia-p5-input-bridge.md
 
 ## Learnings

--- a/.ai-team/decisions/decisions.md
+++ b/.ai-team/decisions/decisions.md
@@ -5,6 +5,63 @@
 
 ---
 
+# Avalonia P5 — TCS-Based Input Bridge
+
+**Date:** 2025-07-17  
+**Architect/Author:** Hill  
+**Issues:** —  
+**PRs:** #1405  
+
+---
+
+## Context
+
+Phase 5 of the Avalonia migration requires bridging the game thread (which blocks waiting for player input) with the Avalonia UI thread (where the TextBox lives). The game loop is single-threaded and synchronous — `ReadCommandInput()` and `ReadLine()` must block until the player submits a command.
+
+## Decision
+
+Use `TaskCompletionSource<string?>` with `TaskCreationOptions.RunContinuationsAsynchronously` to bridge the two threads:
+
+1. **Game thread** creates a TCS and dispatches "enable input" to the UI thread, then blocks on `tcs.Task.GetAwaiter().GetResult()`.
+2. **UI thread** enables the TextBox, auto-focuses it, and waits for Enter.
+3. **On Enter**, the `InputPanelViewModel.Submit()` method fires `InputSubmitted`, which calls `TrySetResult()` on the TCS, unblocking the game thread.
+
+`RunContinuationsAsynchronously` prevents the continuation from running on the UI thread (which would deadlock since the UI thread is dispatching).
+
+### Why not async/await end-to-end?
+
+The entire game loop (`GameLoop.Run`) and all 23 command handlers are synchronous. Converting to async would require rewriting the entire engine. The TCS pattern lets us keep the synchronous game thread while cleanly bridging to the async UI.
+
+### Two consumers, one event
+
+Both `AvaloniaInputReader.ReadLine()` and `AvaloniaDisplayService.ReadCommandInput()` use the same `InputPanelViewModel.InputSubmitted` event. This is safe because:
+- The game thread is single-threaded — only one call blocks at a time.
+- `AvaloniaInputReader` subscribes in its constructor (persistent).
+- `AvaloniaDisplayService` subscribes/unsubscribes per-call (scoped).
+
+## Rationale
+
+- TCS with `RunContinuationsAsynchronously` is the minimal-overhead pattern for single-request async-to-sync bridging
+- Avoids `Channel<string>` complexity for what is always a one-shot request/response
+- Keeps the synchronous game loop intact — no engine-wide async rewrite required
+- Single `InputSubmitted` event safely serves both consumers because the game thread is single-threaded
+
+## Alternatives Considered
+
+- **`Channel<string>`** — more complex, no advantage for single-request pattern.
+- **`AutoResetEvent`** — requires shared mutable string field, less clean.
+- **Full async game loop** — massive rewrite, deferred to post-migration.
+
+## Related Files
+
+- `Dungnz.Display.Avalonia/AvaloniaDisplayService.cs` — `ReadCommandInput()` TCS bridge
+- `Dungnz.Display.Avalonia/AvaloniaInputReader.cs` — `ReadLine()` TCS bridge
+- `Dungnz.Display.Avalonia/ViewModels/InputPanelViewModel.cs` — `InputSubmitted` event + `Submit()`
+- `Dungnz.Display.Avalonia/Views/Panels/InputPanel.axaml` — TextBox + Enter binding
+- `Dungnz.Display.Avalonia/Views/Panels/InputPanel.axaml.cs` — code-behind focus handling
+
+---
+
 # Avalonia P3 Output Panel Architecture
 
 **Date:** 2025-01-12  

--- a/.ai-team/log/2025-07-17-avalonia-p5-input-bridge.md
+++ b/.ai-team/log/2025-07-17-avalonia-p5-input-bridge.md
@@ -1,0 +1,41 @@
+# Session: 2025-07-17 — Avalonia P5 Input Bridge
+
+**Requested by:** Boss  
+**Team:** Hill, Scribe  
+
+---
+
+## What They Did
+
+### Hill — Avalonia P5 Implementation
+
+Implemented the input bridge for Avalonia Phase 5, enabling the game thread to receive typed player commands from the Avalonia UI. Key changes:
+
+- **`AvaloniaDisplayService.cs`** — Added `ReadCommandInput()` using `TaskCompletionSource<string?>` with `RunContinuationsAsynchronously` to bridge the synchronous game thread to the async Avalonia UI thread. Subscribes/unsubscribes to `InputSubmitted` per-call.
+- **`AvaloniaInputReader.cs`** (new) — Created a new `IInputReader` implementation for Avalonia that uses the same TCS pattern in `ReadLine()`. Subscribes to `InputSubmitted` persistently in the constructor.
+- **`InputPanelViewModel.cs`** — Added `InputSubmitted` event and `Submit()` command that fires it, plus `IsInputEnabled` property for toggling the TextBox.
+- **`InputPanel.axaml` / `InputPanel.axaml.cs`** — Added TextBox with Enter key binding and auto-focus behavior via code-behind.
+- **`App.axaml.cs`** — Minor wiring adjustments for the input reader.
+
+Commits:
+- `aba100b` — feat(avalonia): implement ReadCommandInput with TCS pattern (P5)
+- `9e43525` — docs: add P5 decision doc and update Hill history
+
+### Scribe — Decision Merge
+
+Merged the inbox decision file `hill-avalonia-p5-input.md` into `.ai-team/decisions/decisions.md`. Decision documents the TCS-based input bridge architecture, rationale for avoiding async/await engine rewrite, and safety of dual-consumer single-event pattern.
+
+---
+
+## Key Technical Decisions
+
+- **TCS over Channel/AutoResetEvent:** `TaskCompletionSource<string?>` chosen as the minimal-overhead pattern for one-shot sync-to-async bridging. `Channel<string>` rejected as overengineered; `AutoResetEvent` rejected due to shared mutable state.
+- **`RunContinuationsAsynchronously` flag:** Required to prevent continuations from executing on the Avalonia UI thread, which would deadlock.
+- **Two consumers, one event:** `AvaloniaInputReader` (persistent subscriber) and `AvaloniaDisplayService` (scoped subscriber) safely share `InputSubmitted` because the game thread is single-threaded — only one blocks at a time.
+- **`IsInteractive = false`:** Deferred to P6 (menus). For now, the game uses numbered text prompts instead of arrow-key navigation.
+
+---
+
+## Related PRs
+
+- PR #1405: Avalonia P5 — Implement input panel with TCS-based thread bridge


### PR DESCRIPTION
## Summary

Merges the Avalonia P5 decision from the inbox into `decisions.md` and logs the session.

### Changes

- **decisions.md** — Appended "Avalonia P5 — TCS-Based Input Bridge" (author: Hill, PR #1405) as newest entry
- **Session log** — Created `2025-07-17-avalonia-p5-input-bridge.md` documenting Hill's P5 implementation work
- **Scribe history** — Updated with merge and log entries
- **Hill history** — Added one-line cross-reference to the new decision

### Inbox consumed

- `hill-avalonia-p5-input.md` from `squad/avalonia-p5-input-panel` branch — that branch's PR should remove the inbox file when it merges

### Note

Hill's `history.md` is ~125KB, well over the 12KB archival threshold. A separate archival pass is recommended.

---

*Automated by Scribe. Coulson to review.*