### PR TITLE
chore: bump Avalonia.Themes.Fluent 11.3.2 → 11.3.12

### DIFF
--- a/Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj
+++ b/Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj
@@ -21,7 +21,7 @@
     <!-- Avalonia 11.x — stable release line -->
     <PackageReference Include="Avalonia" Version="11.3.12" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
     <!-- CommunityToolkit.Mvvm for ObservableObject + source generators -->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <!-- Logging (same as console app) -->


### PR DESCRIPTION
Completes the Avalonia 11.3.12 version alignment. PR #1409 was closed due to merge conflict with #1408 — this applies the remaining Avalonia.Themes.Fluent bump to match the core Avalonia and Desktop versions.