### PR TITLE
test: Interface conformance + MapRenderer unit tests (Regression Wave 1)

### DIFF
--- a/.ai-team/agents/romanoff/history.md
+++ b/.ai-team/agents/romanoff/history.md
@@ -1575,3 +1575,55 @@ This PR implements:
 
 **Next steps for Hill (P3):** Implement actual panel rendering in AvaloniaDisplayService using MapRenderer.BuildPlainTextMap, data-binding to ViewModels, and Avalonia-native input handling (no more ConsoleInputReader temp stub).
 
+
+---
+
+## Regression Wave 1: Interface Conformance + MapRenderer Unit Tests (2026-03-14)
+
+**Branch:** `squad/regression-wave1-romanoff`
+**PR:** test: Interface conformance + MapRenderer unit tests (Regression Wave 1)
+
+### WI-R01: Interface Conformance Tests
+
+**File:** `Dungnz.Tests/Architecture/InterfaceSplitTests.cs`
+**Tests added:** 8
+
+Verified the IDisplayService ↔ IGameDisplay / IGameInput interface split (Avalonia P0):
+
+1. `IDisplayService_InheritsAllMethodsFrom_IGameDisplay` — every IGameDisplay method reachable through IDisplayService
+2. `IDisplayService_InheritsAllMethodsFrom_IGameInput` — every IGameInput method reachable through IDisplayService
+3. `IDisplayService_HasNoMethodsOutside_IGameDisplay_Or_IGameInput` — facade declares no extra methods
+4. `FakeDisplayService_Implements_IDisplayService` — test double satisfies facade + both sub-interfaces
+5. `FakeDisplayService_CanBeAssignedTo_EitherSubInterface` — runtime assignment verification
+6. `EngineAndSystems_DoNotDependDirectlyOn_IGameDisplay` — reflection scan of Engine/Systems ctors, fields, properties
+7. `IDisplayService_InheritsExactly_IGameDisplay_And_IGameInput` — verifies inheritance chain
+8. `InterfaceMethodCounts_AreConsistent` — IDisplayService declares 0 own methods (pure union)
+
+### WI-R03: MapRenderer Unit Tests
+
+**File:** `Dungnz.Tests/MapRendererTests.cs`
+**Tests added:** 28
+
+Comprehensive tests for the BFS-based ASCII map renderer:
+
+- **Grid generation (5):** Single room, linear corridor, T-intersection, cyclic rooms, larger dungeon
+- **Connectors (3):** East horizontal, south vertical, isolated (no connectors)
+- **Current room indicator (2):** `[@]` for current, `[+]` for cleared
+- **Plain text vs markup (3):** No Spectre tags in plain, valid markup in markup, consistent line counts
+- **Edge cases (2):** Unvisited neighbors as `[?]`, rooms with live enemies as `[!]`
+- **Symbol priority chain (5):** Boss `[B]` > Exit `[E]`, shrine `[S]`, merchant `[M]`, trap `[T]`
+- **Map features (3):** Compass header, legend `[@] You`, markup legend uses color tags
+- **Entrance visibility (2):** `[^]` on floor > 1, suppressed on floor 1
+- **Fog of war (1):** Two-hop unvisited rooms hidden
+- **Special rooms (2):** Dark `[D]`, Blessed `[*]`
+
+### Test Counts
+- **Before:** 2,154 passing
+- **After:** 2,190 passing (+36 new)
+- **Skipped:** 4 pre-existing momentum integration skips
+- **Known flake:** ShieldBash_AppliesStunWithMockedRng (pre-existing, order-sensitive)
+
+### Learnings
+- **Legend symbol counting trap:** `CountOccurrences("[@]")` on full map text double-counts legend entries like `[@] You`. Must extract grid section before legend for exact room counts.
+- **Namespace collision:** Creating `Dungnz.Tests.Architecture` namespace conflicts with ArchUnitNET `Architecture` type used in existing `ArchitectureTests.cs`. Used `Dungnz.Tests.ArchRules` to match existing convention.
+- **BFS visibility model:** Rooms visible = visited ∪ current ∪ neighbors-of-(visited ∪ current). Rooms 2+ hops from any visited room are hidden (fog of war).

--- a/.ai-team/decisions/inbox/romanoff-regression-wave1.md
+++ b/.ai-team/decisions/inbox/romanoff-regression-wave1.md
@@ -1,0 +1,32 @@
+# Decision: Regression Wave 1 — Interface Conformance + MapRenderer Tests
+
+**Author:** Romanoff (QA)
+**Date:** 2026-03-14
+**Status:** Proposed
+**Scope:** Dungnz.Tests
+
+## Context
+
+The Avalonia migration Phase 0 split `IDisplayService` into `IGameDisplay` (output-only) and `IGameInput` (input-coupled), with `IDisplayService` as a union facade. Phase 1 extracted `MapRenderer` as a static utility class. Both changes shipped with zero regression tests.
+
+## Decision
+
+Add 36 regression tests across two test files:
+
+1. **`Dungnz.Tests/Architecture/InterfaceSplitTests.cs`** (8 tests) — Reflection-based verification that the interface split is structurally sound: inheritance chain, method coverage, no extra surface, FakeDisplayService conformance, and Engine/Systems dependency direction.
+
+2. **`Dungnz.Tests/MapRendererTests.cs`** (28 tests) — Behavioral tests for `BuildPlainTextMap()` and `BuildMarkupMap()` covering grid generation, BFS correctness, connector rendering, room symbol priority chain, fog of war visibility, legend generation, and edge cases.
+
+## Rationale
+
+- These are pure regression tests — they verify existing behavior, not new features
+- The interface split is a load-bearing architectural decision; any drift should be caught immediately
+- MapRenderer is used by both Console and Avalonia display implementations; correctness is critical
+- Both systems had 0% test coverage before this change
+
+## Consequences
+
+- Test count: 2,154 → 2,190 (+36)
+- No production code changes
+- Coverage improves for Dungnz.Models (MapRenderer) and architecture rule enforcement
+- Future changes to the interface hierarchy or map rendering will be caught by these tests

--- a/Dungnz.Tests/Architecture/InterfaceSplitTests.cs
+++ b/Dungnz.Tests/Architecture/InterfaceSplitTests.cs
@@ -1,0 +1,219 @@
+using System.Reflection;
+using Dungnz.Models;
+using Dungnz.Tests.Helpers;
+using FluentAssertions;
+
+namespace Dungnz.Tests.ArchRules;
+
+/// <summary>
+/// Verifies the IDisplayService ↔ IGameDisplay / IGameInput interface split
+/// introduced in the Avalonia migration Phase 0.
+///
+/// These tests use reflection to confirm:
+/// 1. IDisplayService is the exhaustive union of IGameDisplay + IGameInput
+/// 2. FakeDisplayService (test double) implements the facade
+/// 3. Engine/Systems classes depend only on IDisplayService, not the sub-interfaces
+/// </summary>
+public class InterfaceSplitTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the set of method signatures (Name + parameter types) declared
+    /// directly on the given interface, excluding default-implemented methods'
+    /// bodies but including their declarations.
+    /// </summary>
+    private static HashSet<string> GetMethodSignatures(Type iface)
+    {
+        return iface
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Select(m => $"{m.Name}({string.Join(",", m.GetParameters().Select(p => p.ParameterType.FullName))})")
+            .ToHashSet();
+    }
+
+    // ── 1. Every IGameDisplay method exists on IDisplayService ───────────────
+
+    [Fact]
+    public void IDisplayService_InheritsAllMethodsFrom_IGameDisplay()
+    {
+        // Arrange
+        var displayMethods = typeof(IGameDisplay)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        var facadeMethods = typeof(IDisplayService)
+            .GetInterfaces()
+            .SelectMany(i => i.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Select(m => m.Name)
+            .ToHashSet();
+
+        // Act & Assert — every IGameDisplay method should be reachable through IDisplayService
+        foreach (var method in displayMethods)
+        {
+            facadeMethods.Should().Contain(method.Name,
+                because: $"IDisplayService must expose IGameDisplay.{method.Name}");
+        }
+    }
+
+    // ── 2. Every IGameInput method exists on IDisplayService ─────────────────
+
+    [Fact]
+    public void IDisplayService_InheritsAllMethodsFrom_IGameInput()
+    {
+        // Arrange
+        var inputMethods = typeof(IGameInput)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        var facadeMethods = typeof(IDisplayService)
+            .GetInterfaces()
+            .SelectMany(i => i.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Select(m => m.Name)
+            .ToHashSet();
+
+        // Act & Assert — every IGameInput method should be reachable through IDisplayService
+        foreach (var method in inputMethods)
+        {
+            facadeMethods.Should().Contain(method.Name,
+                because: $"IDisplayService must expose IGameInput.{method.Name}");
+        }
+    }
+
+    // ── 3. IDisplayService is the exhaustive union (no extra methods) ────────
+
+    [Fact]
+    public void IDisplayService_HasNoMethodsOutside_IGameDisplay_Or_IGameInput()
+    {
+        // Arrange — methods declared directly on IDisplayService (not inherited)
+        var ownMethods = typeof(IDisplayService)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        var displaySigs = GetMethodSignatures(typeof(IGameDisplay));
+        var inputSigs = GetMethodSignatures(typeof(IGameInput));
+        var unionSigs = displaySigs.Union(inputSigs).ToHashSet();
+
+        // Act & Assert — any method declared directly on IDisplayService must also
+        // appear in IGameDisplay or IGameInput (the facade adds no extra surface).
+        foreach (var method in ownMethods)
+        {
+            var sig = $"{method.Name}({string.Join(",", method.GetParameters().Select(p => p.ParameterType.FullName))})";
+            unionSigs.Should().Contain(sig,
+                because: $"IDisplayService.{method.Name} should come from IGameDisplay or IGameInput, not be declared independently");
+        }
+    }
+
+    // ── 4. FakeDisplayService implements IDisplayService (and therefore both) ─
+
+    [Fact]
+    public void FakeDisplayService_Implements_IDisplayService()
+    {
+        // Arrange & Act
+        var fakeType = typeof(FakeDisplayService);
+
+        // Assert
+        fakeType.Should().Implement<IDisplayService>(
+            because: "the test double must satisfy the full facade");
+        fakeType.Should().Implement<IGameDisplay>(
+            because: "IDisplayService inherits IGameDisplay");
+        fakeType.Should().Implement<IGameInput>(
+            because: "IDisplayService inherits IGameInput");
+    }
+
+    [Fact]
+    public void FakeDisplayService_CanBeAssignedTo_EitherSubInterface()
+    {
+        // Arrange
+        var fake = new FakeDisplayService();
+
+        // Act & Assert — runtime assignment must succeed for both sub-interfaces
+        IGameDisplay display = fake;
+        IGameInput input = fake;
+
+        display.Should().NotBeNull();
+        input.Should().NotBeNull();
+    }
+
+    // ── 5. Engine/Systems classes depend only on IDisplayService ─────────────
+
+    [Fact]
+    public void EngineAndSystems_DoNotDependDirectlyOn_IGameDisplay()
+    {
+        // Arrange — load all concrete types from Engine and Systems assemblies
+        var engineAssembly = typeof(Dungnz.Engine.GameLoop).Assembly;
+        var systemsAssembly = typeof(Dungnz.Systems.InventoryManager).Assembly;
+
+        var allTypes = engineAssembly.GetTypes()
+            .Concat(systemsAssembly.GetTypes())
+            .Where(t => t.IsClass && !t.IsAbstract);
+
+        var violations = new List<string>();
+
+        // Act — scan constructors, fields, properties, and method parameters
+        foreach (var type in allTypes)
+        {
+            // Constructor parameters
+            foreach (var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            {
+                foreach (var param in ctor.GetParameters())
+                {
+                    if (param.ParameterType == typeof(IGameDisplay) || param.ParameterType == typeof(IGameInput))
+                        violations.Add($"{type.Name} ctor param '{param.Name}' uses {param.ParameterType.Name}");
+                }
+            }
+
+            // Fields
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+            {
+                if (field.FieldType == typeof(IGameDisplay) || field.FieldType == typeof(IGameInput))
+                    violations.Add($"{type.Name} field '{field.Name}' uses {field.FieldType.Name}");
+            }
+
+            // Properties
+            foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+            {
+                if (prop.PropertyType == typeof(IGameDisplay) || prop.PropertyType == typeof(IGameInput))
+                    violations.Add($"{type.Name} property '{prop.Name}' uses {prop.PropertyType.Name}");
+            }
+        }
+
+        // Assert
+        violations.Should().BeEmpty(
+            because: "Engine and Systems classes should depend on IDisplayService, not on the narrower IGameDisplay/IGameInput sub-interfaces");
+    }
+
+    // ── 6. IDisplayService inherits exactly two interfaces ───────────────────
+
+    [Fact]
+    public void IDisplayService_InheritsExactly_IGameDisplay_And_IGameInput()
+    {
+        // Arrange
+        var directBases = typeof(IDisplayService).GetInterfaces();
+
+        // Assert
+        directBases.Should().Contain(typeof(IGameDisplay));
+        directBases.Should().Contain(typeof(IGameInput));
+    }
+
+    // ── 7. Method counts are consistent ─────────────────────────────────────
+
+    [Fact]
+    public void InterfaceMethodCounts_AreConsistent()
+    {
+        // Arrange
+        var displayCount = typeof(IGameDisplay)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Length;
+
+        var inputCount = typeof(IGameInput)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Length;
+
+        var facadeDeclaredCount = typeof(IDisplayService)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Length;
+
+        // Act & Assert
+        displayCount.Should().BeGreaterThan(0, because: "IGameDisplay should declare output methods");
+        inputCount.Should().BeGreaterThan(0, because: "IGameInput should declare input methods");
+        facadeDeclaredCount.Should().Be(0,
+            because: "IDisplayService should declare no methods of its own — it's a pure union");
+    }
+}

--- a/Dungnz.Tests/MapRendererTests.cs
+++ b/Dungnz.Tests/MapRendererTests.cs
@@ -1,0 +1,620 @@
+using Dungnz.Models;
+using Dungnz.Tests.Builders;
+using FluentAssertions;
+
+namespace Dungnz.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MapRenderer"/> — the static BFS-based ASCII map renderer
+/// extracted as part of the Avalonia migration Phase 1.
+///
+/// Tests cover grid generation, connector rendering, current room indicator,
+/// plain text vs markup output, room symbol priority chain, and edge cases.
+/// </summary>
+public class MapRendererTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>Creates a room with an optional description and marks it visited.</summary>
+    private static Room MakeRoom(string description = "A room", bool visited = true)
+    {
+        return new Room { Description = description, Visited = visited };
+    }
+
+    /// <summary>Links two rooms bidirectionally along the given axis.</summary>
+    private static void Link(Room from, Direction dir, Room to)
+    {
+        from.Exits[dir] = to;
+        to.Exits[Opposite(dir)] = from;
+    }
+
+    private static Direction Opposite(Direction d) => d switch
+    {
+        Direction.North => Direction.South,
+        Direction.South => Direction.North,
+        Direction.East => Direction.West,
+        Direction.West => Direction.East,
+        _ => throw new ArgumentOutOfRangeException(nameof(d))
+    };
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Grid Generation
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 1. Single room — produces valid output with the current-room marker ─
+
+    [Fact]
+    public void BuildPlainTextMap_SingleRoom_ContainsCurrentRoomMarker()
+    {
+        // Arrange
+        var room = MakeRoom("Starting room");
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(room);
+
+        // Assert
+        map.Should().Contain("[@]", because: "the only room is the current room");
+    }
+
+    // ── 2. Linear corridor N→S — rooms appear in correct vertical order ─────
+
+    [Fact]
+    public void BuildPlainTextMap_LinearCorridor_RoomsInVerticalOrder()
+    {
+        // Arrange: A (current) ─south→ B ─south→ C
+        var a = MakeRoom("Room A");
+        var b = MakeRoom("Room B");
+        var c = MakeRoom("Room C");
+        Link(a, Direction.South, b);
+        Link(b, Direction.South, c);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(a);
+
+        // Assert — [@] (current) should appear before the other rooms vertically
+        var lines = map.Split('\n');
+        int currentLine = Array.FindIndex(lines, l => l.Contains("[@]"));
+        int lastRoomLine = Array.FindLastIndex(lines, l => l.Contains("[+]") || l.Contains("[?]"));
+
+        currentLine.Should().BeLessThan(lastRoomLine,
+            because: "current room is north, linked rooms are south (lower on map)");
+    }
+
+    // ── 3. Branching dungeon (T-intersection) — all branches rendered ────────
+
+    [Fact]
+    public void BuildPlainTextMap_TIntersection_AllBranchesPresent()
+    {
+        // Arrange: center (current) with east, west, and south exits
+        var center = MakeRoom("Center");
+        var east = MakeRoom("East wing");
+        var west = MakeRoom("West wing");
+        var south = MakeRoom("South wing");
+        Link(center, Direction.East, east);
+        Link(center, Direction.West, west);
+        Link(center, Direction.South, south);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(center);
+
+        // Assert — grid section (before legend) contains 1 current + 3 cleared = 4 room symbols
+        var grid = GetGridSection(map);
+        int roomSymbolCount = CountOccurrences(grid, "[@]") + CountOccurrences(grid, "[+]");
+        roomSymbolCount.Should().Be(4, because: "center + 3 branches = 4 rooms in grid");
+    }
+
+    // ── 4. Cyclic dungeon — no infinite loop or duplicate cells ──────────────
+
+    [Fact]
+    public void BuildPlainTextMap_CyclicRooms_NoInfiniteLoopOrDuplicate()
+    {
+        // Arrange: A→B→C→A (triangle)
+        var a = MakeRoom("Room A");
+        var b = MakeRoom("Room B");
+        var c = MakeRoom("Room C");
+        Link(a, Direction.East, b);
+        Link(b, Direction.South, c);
+        Link(c, Direction.West, a);
+
+        // Act — should terminate without hanging
+        var map = MapRenderer.BuildPlainTextMap(a);
+
+        // Assert — grid section has exactly 3 rooms (1 current + 2 cleared)
+        var grid = GetGridSection(map);
+        int roomCount = CountOccurrences(grid, "[@]") + CountOccurrences(grid, "[+]");
+        roomCount.Should().Be(3, because: "BFS should visit each room exactly once in the grid");
+    }
+
+    // ── 5. Larger dungeon — no index-out-of-bounds ──────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_LargerDungeon_NoException()
+    {
+        // Arrange: 5×1 east corridor
+        var rooms = Enumerable.Range(0, 5).Select(i => MakeRoom($"Room {i}")).ToList();
+        for (int i = 0; i < rooms.Count - 1; i++)
+            Link(rooms[i], Direction.East, rooms[i + 1]);
+
+        // Act
+        var act = () => MapRenderer.BuildPlainTextMap(rooms[0]);
+
+        // Assert
+        act.Should().NotThrow(because: "a 5-room dungeon must render without overflow");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Connector Rendering
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 6. East exit — horizontal connector ─────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_EastExit_HorizontalConnector()
+    {
+        // Arrange
+        var a = MakeRoom("Room A");
+        var b = MakeRoom("Room B");
+        Link(a, Direction.East, b);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(a);
+
+        // Assert — horizontal connector character should appear between rooms
+        map.Should().Contain("─", because: "east exit renders a horizontal connector");
+    }
+
+    // ── 7. South exit — vertical connector ──────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_SouthExit_VerticalConnector()
+    {
+        // Arrange
+        var a = MakeRoom("Room A");
+        var b = MakeRoom("Room B");
+        Link(a, Direction.South, b);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(a);
+
+        // Assert
+        map.Should().Contain("│", because: "south exit renders a vertical connector");
+    }
+
+    // ── 8. Room with no exits — isolated cell, no connectors ────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_IsolatedRoom_NoConnectors()
+    {
+        // Arrange
+        var room = MakeRoom("Isolated");
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(room);
+
+        // Assert
+        map.Should().NotContain("─", because: "no east exit means no horizontal connector");
+        map.Should().NotContain("│", because: "no south exit means no vertical connector");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Current Room Indicator
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 9. Current room is visually marked as [@] ───────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_CurrentRoom_MarkedAsAtSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Current");
+        var neighbor = MakeRoom("Neighbor");
+        Link(current, Direction.East, neighbor);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[@]", because: "the current room is always shown as [@]");
+    }
+
+    // ── 10. Non-current visited rooms use [+] marker ────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_VisitedNonCurrentRoom_MarkedAsCleared()
+    {
+        // Arrange — neighbor is visited with no enemy/shrine/special
+        var current = MakeRoom("Current");
+        var neighbor = MakeRoom("Neighbor", visited: true);
+        Link(current, Direction.East, neighbor);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[+]", because: "a visited, cleared room uses the [+] symbol");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Plain Text vs Markup
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 11. Plain text output contains no Spectre markup tags ────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_NoSpectreMarkupTags()
+    {
+        // Arrange
+        var room = MakeRoom("Test room");
+        var neighbor = MakeRoom("Neighbor");
+        Link(room, Direction.East, neighbor);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(room);
+
+        // Assert — strip out the room symbol brackets like [+], [@], [?] etc.,
+        // then confirm no remaining [color]...[/] patterns
+        var withoutRoomSymbols = System.Text.RegularExpressions.Regex.Replace(map, @"\[[@+?!BESAMTLFD~*^]\]", "");
+        withoutRoomSymbols.Should().NotMatchRegex(@"\[[a-z].*?\]",
+            because: "plain text output must not contain Spectre [color]...[/] markup");
+    }
+
+    // ── 12. Markup output contains Spectre color tags ───────────────────────
+
+    [Fact]
+    public void BuildMarkupMap_ContainsSpectreMarkupSyntax()
+    {
+        // Arrange
+        var room = MakeRoom("Test room");
+
+        // Act
+        var map = MapRenderer.BuildMarkupMap(room);
+
+        // Assert — must contain at least one Spectre color tag
+        map.Should().Contain("[bold yellow]", because: "current room uses [bold yellow] markup");
+        map.Should().Contain("[/]", because: "Spectre markup tags must be closed");
+    }
+
+    // ── 13. Both methods produce consistent spatial layout ──────────────────
+
+    [Fact]
+    public void BothMethods_ProduceConsistentLineCount()
+    {
+        // Arrange — same dungeon for both
+        var center = MakeRoom("Center");
+        var east = MakeRoom("East");
+        var south = MakeRoom("South");
+        Link(center, Direction.East, east);
+        Link(center, Direction.South, south);
+
+        // Act
+        var plain = MapRenderer.BuildPlainTextMap(center);
+        var markup = MapRenderer.BuildMarkupMap(center);
+
+        var plainLines = plain.Split('\n').Length;
+        var markupLines = markup.Split('\n').Length;
+
+        // Assert — both should produce the same number of lines
+        plainLines.Should().Be(markupLines,
+            because: "plain and markup variants use the same BFS grid and layout logic");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Edge Cases
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 14. Unvisited neighbor — shown as [?] ───────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_UnvisitedNeighbor_ShownAsUnknown()
+    {
+        // Arrange — neighbor has not been visited
+        var current = MakeRoom("Current");
+        var unvisited = MakeRoom("Unvisited", visited: false);
+        Link(current, Direction.East, unvisited);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[?]", because: "unvisited rooms render as [?]");
+    }
+
+    // ── 15. Room with exit to room that has an enemy — shows [!] ────────────
+
+    [Fact]
+    public void BuildPlainTextMap_RoomWithEnemy_ShowsExclamation()
+    {
+        // Arrange
+        var current = MakeRoom("Safe room");
+        var dangerRoom = MakeRoom("Danger room");
+        dangerRoom.Enemy = new EnemyBuilder().WithHP(10).Build();
+        Link(current, Direction.East, dangerRoom);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[!]", because: "a visited room with a live enemy renders as [!]");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Room Symbol Priority Chain
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 16. Exit room with boss — shows [B] not [E] ─────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_ExitRoomWithBoss_ShowsBossSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Start");
+        var bossRoom = MakeRoom("Boss room");
+        bossRoom.IsExit = true;
+        bossRoom.Enemy = new EnemyBuilder().WithHP(100).Build();
+        Link(current, Direction.East, bossRoom);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[B]", because: "exit room with live boss shows [B], not [E]");
+        map.Should().NotContain("[E]", because: "boss symbol takes priority over exit");
+    }
+
+    // ── 17. Exit room without boss — shows [E] ─────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_ClearedExitRoom_ShowsExitSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Start");
+        var exitRoom = MakeRoom("Exit");
+        exitRoom.IsExit = true;
+        exitRoom.Enemy = null; // boss defeated
+        Link(current, Direction.East, exitRoom);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[E]", because: "exit room with no live boss shows [E]");
+    }
+
+    // ── 18. Shrine room — shows [S] ─────────────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_ShrineRoom_ShowsShrineSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Start");
+        var shrine = MakeRoom("Shrine");
+        shrine.HasShrine = true;
+        shrine.ShrineUsed = false;
+        Link(current, Direction.East, shrine);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[S]", because: "unused shrine renders as [S]");
+    }
+
+    // ── 19. Merchant room — shows [M] ───────────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_MerchantRoom_ShowsMerchantSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Start");
+        var shopRoom = MakeRoom("Shop");
+        shopRoom.Merchant = new Merchant();
+        Link(current, Direction.East, shopRoom);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[M]", because: "room with a merchant renders as [M]");
+    }
+
+    // ── 20. Trap room — shows [T] ───────────────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_TrapRoom_ShowsTrapSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Start");
+        var trapRoom = MakeRoom("Trap");
+        trapRoom.Type = RoomType.TrapRoom;
+        trapRoom.SpecialRoomUsed = false;
+        Link(current, Direction.East, trapRoom);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[T]", because: "an unsprung trap room renders as [T]");
+    }
+
+    // ── 21. Compass header is present ───────────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_AlwaysShowsCompassHeader()
+    {
+        // Arrange
+        var room = MakeRoom("Solo");
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(room);
+
+        // Assert
+        map.Should().Contain("N", because: "the compass header should show cardinal directions");
+        map.Should().Contain("W", because: "the compass header should show W");
+        map.Should().Contain("E", because: "the compass header should show E");
+        map.Should().Contain("S", because: "the compass header should show S");
+    }
+
+    // ── 22. Legend includes "You" label ──────────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_LegendContainsYouLabel()
+    {
+        // Arrange
+        var room = MakeRoom("Solo");
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(room);
+
+        // Assert
+        map.Should().Contain("[@] You", because: "the legend always lists the current-room symbol");
+    }
+
+    // ── 23. Markup map legend uses color tags ────────────────────────────────
+
+    [Fact]
+    public void BuildMarkupMap_LegendUsesColorTags()
+    {
+        // Arrange — room with enemy so legend has entries beyond just "You"
+        var current = MakeRoom("Start");
+        var enemyRoom = MakeRoom("Enemy");
+        enemyRoom.Enemy = new EnemyBuilder().WithHP(10).Build();
+        Link(current, Direction.East, enemyRoom);
+
+        // Act
+        var map = MapRenderer.BuildMarkupMap(current);
+
+        // Assert
+        map.Should().Contain("[bold yellow]", because: "markup legend includes colored [@] You entry");
+        map.Should().Contain("[red]", because: "enemy room triggers [red] legend entry");
+    }
+
+    // ── 24. Entrance room on floor > 1 — shows [^] ─────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_EntranceOnFloorGreaterThan1_ShowsEntranceSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Current");
+        var entrance = MakeRoom("Entrance");
+        entrance.IsEntrance = true;
+        Link(current, Direction.North, entrance);
+
+        // Act — floor 2 means entrance is visible
+        var map = MapRenderer.BuildPlainTextMap(current, currentFloor: 2);
+
+        // Assert
+        map.Should().Contain("[^]", because: "entrance room on floor > 1 renders as [^]");
+    }
+
+    // ── 25. Entrance room on floor 1 — does NOT show [^] ───────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_EntranceOnFloor1_DoesNotShowEntranceSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Current");
+        var entrance = MakeRoom("Entrance");
+        entrance.IsEntrance = true;
+        Link(current, Direction.North, entrance);
+
+        // Act — floor 1 means entrance symbol is suppressed
+        var map = MapRenderer.BuildPlainTextMap(current, currentFloor: 1);
+
+        // Assert
+        map.Should().NotContain("[^]",
+            because: "entrance symbol is only shown when currentFloor > 1");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Visibility / Fog of War
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 26. Room two hops away from visited — not visible ───────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_RoomTwoHopsFromVisited_NotRendered()
+    {
+        // Arrange: current → unvisited_mid → unvisited_far
+        var current = MakeRoom("Current");
+        var mid = new Room { Description = "Mid", Visited = false };
+        var far = new Room { Description = "Far", Visited = false };
+        Link(current, Direction.East, mid);
+        Link(mid, Direction.East, far);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert — grid section: mid is neighbor of current (visible as [?]),
+        // far is neighbor of unvisited mid (not in knownSet), so hidden.
+        // Only count [?] in the grid section (legend also contains "[?] Unknown").
+        var grid = GetGridSection(map);
+        int unknownCount = CountOccurrences(grid, "[?]");
+        unknownCount.Should().Be(1, because: "only mid (direct neighbor of current) is visible as [?]; far is hidden");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Special Room Types
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── 27. Dark room — shows [D] ───────────────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_DarkRoom_ShowsDarkSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Start");
+        var dark = MakeRoom("Dark");
+        dark.Type = RoomType.Dark;
+        Link(current, Direction.East, dark);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[D]", because: "a dark room renders as [D]");
+    }
+
+    // ── 28. Blessed clearing — shows [*] ────────────────────────────────────
+
+    [Fact]
+    public void BuildPlainTextMap_BlessedClearing_ShowsBlessedSymbol()
+    {
+        // Arrange
+        var current = MakeRoom("Start");
+        var blessed = MakeRoom("Blessed");
+        blessed.EnvironmentalHazard = RoomHazard.BlessedClearing;
+        Link(current, Direction.East, blessed);
+
+        // Act
+        var map = MapRenderer.BuildPlainTextMap(current);
+
+        // Assert
+        map.Should().Contain("[*]", because: "blessed clearing renders as [*]");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //  Utility
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0, idx = 0;
+        while ((idx = text.IndexOf(pattern, idx, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            idx += pattern.Length;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Returns the grid portion of a map string (everything before the legend).
+    /// The legend is separated from the grid by a blank line.
+    /// </summary>
+    private static string GetGridSection(string map)
+    {
+        // MapRenderer separates grid from legend with a blank line (AppendLine() after grid)
+        var doubleNewline = map.IndexOf("\n\n", StringComparison.Ordinal);
+        return doubleNewline >= 0 ? map[..doubleNewline] : map;
+    }
+}


### PR DESCRIPTION
## Regression Wave 1 — WI-R01 + WI-R03

### Summary

Adds **36 new regression tests** for Avalonia migration Phase 0/Phase 1 extractions that shipped with zero test coverage.

**Test count: 2,154 → 2,190 (+36)**

### WI-R01: Interface Conformance Tests (8 tests)

**File:** `Dungnz.Tests/Architecture/InterfaceSplitTests.cs`

Reflection-based verification that the `IDisplayService` ↔ `IGameDisplay` / `IGameInput` interface split is structurally sound:

| # | Test | Verifies |
|---|------|----------|
| 1 | `IDisplayService_InheritsAllMethodsFrom_IGameDisplay` | Every IGameDisplay method reachable through IDisplayService |
| 2 | `IDisplayService_InheritsAllMethodsFrom_IGameInput` | Every IGameInput method reachable through IDisplayService |
| 3 | `IDisplayService_HasNoMethodsOutside_IGameDisplay_Or_IGameInput` | Facade declares no extra methods (pure union) |
| 4 | `FakeDisplayService_Implements_IDisplayService` | Test double satisfies facade + both sub-interfaces |
| 5 | `FakeDisplayService_CanBeAssignedTo_EitherSubInterface` | Runtime assignment works for both narrow types |
| 6 | `EngineAndSystems_DoNotDependDirectlyOn_IGameDisplay` | Engine/Systems ctors, fields, props use only IDisplayService |
| 7 | `IDisplayService_InheritsExactly_IGameDisplay_And_IGameInput` | Inheritance chain is correct |
| 8 | `InterfaceMethodCounts_AreConsistent` | IDisplayService declares 0 own methods |

### WI-R03: MapRenderer Unit Tests (28 tests)

**File:** `Dungnz.Tests/MapRendererTests.cs`

Behavioral tests for the BFS-based ASCII map renderer (`BuildPlainTextMap` + `BuildMarkupMap`):

- **Grid generation (5):** Single room, linear corridor, T-intersection, cyclic rooms, larger dungeon
- **Connector rendering (3):** East horizontal `─`, south vertical `│`, isolated room (none)
- **Current room indicator (2):** `[@]` for current, `[+]` for cleared
- **Plain text vs markup (3):** No Spectre tags in plain text, valid markup in colored variant, consistent line counts
- **Edge cases (2):** Unvisited neighbors as `[?]`, rooms with live enemies as `[!]`
- **Symbol priority chain (5):** Boss `[B]` > Exit `[E]`, Shrine `[S]`, Merchant `[M]`, Trap `[T]`
- **Map features (3):** Compass header, legend `[@] You` label, markup legend color tags
- **Entrance visibility (2):** `[^` on floor > 1, suppressed on floor 1
- **Fog of war (1):** Two-hop unvisited rooms hidden from grid
- **Special rooms (2):** Dark `[D]`, Blessed Clearing `[*]`

### No Production Code Changes

This PR is test-only — no changes to `Engine/`, `Systems/`, `Models/`, or `Display/`.

### Pre-existing Failures

- `ShieldBash_AppliesStunWithMockedRng` — known order-sensitive flake, pre-existing
- 4 momentum integration tests — pre-existing `[Skip]` annotations

---

Part of the Avalonia Regression Phase plan. Decision record: `.ai-team/decisions/inbox/romanoff-regression-wave1.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>