### PR TITLE
docs: Avalonia smoke test checklist (Regression Wave 2)

### DIFF
--- a/.ai-team/agents/hill/history.md
+++ b/.ai-team/agents/hill/history.md
@@ -2253,3 +2253,41 @@ ReadCommandInput() unblocks ←────────
 - ✅ `dotnet build Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj` — 0 errors
 - ✅ `dotnet test` — 2,154 passed, 0 failed, 4 skipped
 - ✅ Only `Dungnz.Display.Avalonia/` files touched (no README update needed)
+
+---
+
+## Regression Wave 2 (2026-03-21)
+
+### WI-R09: Avalonia Smoke Test Checklist
+
+**Issue:** #1419
+**Branch:** `squad/regression-wave2-hill`
+
+Created `docs/avalonia-smoke-test-checklist.md` — a 12-scenario manual smoke test checklist for the Avalonia GUI frontend.
+
+**Checklist covers:**
+1. Application launch (window opens, 6-panel layout)
+2. Map panel renders ASCII dungeon map
+3. Stats panel shows player name, HP bar, level
+4. Content panel shows room description
+5. Gear panel shows equipment slots
+6. Log panel accumulates timestamped messages
+7. Input panel accepts typing
+8. Command submission via Enter
+9. Movement command (directional)
+10. Quit command
+11. Window close via X button
+12. Window resize / reflow
+
+**Audit findings — hardcoded values in `App.axaml.cs`:**
+- `Difficulty.Normal` (line 49) — should be player-selectable
+- Seed `12345` (line 59) — should be random or player-entered
+- Player name `"Adventurer"` (line 62) — should be player-entered
+- Player class `PlayerClass.Warrior` (line 63) — should be player-selectable
+- All intentional P2 scaffolding; full startup flow planned for P3–P8
+
+**Headless verification attempt:**
+- ✅ Build succeeds (0 errors)
+- ✅ App launches, logs "Dungnz Avalonia GUI starting..."
+- ⚠️ Cannot interactively test — headless session, killed by timeout (exit 124)
+- Conclusion: App initializes correctly; interactive testing requires desktop environment

--- a/.ai-team/decisions/inbox/hill-regression-wave2.md
+++ b/.ai-team/decisions/inbox/hill-regression-wave2.md
@@ -1,0 +1,37 @@
+# Decision: Avalonia Smoke Test Checklist (Regression Wave 2)
+
+**Author:** Hill
+**Date:** 2026-03-21
+**Status:** Proposed
+**Issue:** #1419
+
+## Context
+
+Regression Wave 2 tasked Hill with creating a manual smoke test checklist for the Avalonia GUI (`Dungnz.Display.Avalonia/`). The P2 milestone delivered a functional 6-panel window but lacked any documented verification procedure.
+
+## Decision
+
+Created `docs/avalonia-smoke-test-checklist.md` with 12 scenarios covering:
+- Application lifecycle (launch, quit, window close)
+- All 6 panels (Map, Stats, Content, Gear, Log, Input)
+- User interaction (typing, command submission, movement)
+- Resilience (window resize)
+
+Additionally audited `App.axaml.cs` and documented 4 hardcoded values (difficulty, seed, player name, player class) that are P2 scaffolding and must become configurable in P3–P8.
+
+## Verification
+
+- Build: ✅ 0 errors
+- Headless launch: App starts and logs initialization, but interactive testing not possible in CI/headless
+- Checklist is designed for local developer use on a desktop workstation
+
+## Risks
+
+- **Low:** Checklist may drift from implementation as panels evolve — should be updated alongside Avalonia display changes.
+- **None:** This is documentation-only; no code changes to game logic.
+
+## Action Items
+
+- [ ] Coulson: Review and approve checklist coverage
+- [ ] Team: Run checklist on desktop environment and fill in Pass/Fail column
+- [ ] P3–P8: Remove hardcoded values in `App.axaml.cs` as startup flow is implemented

--- a/docs/avalonia-smoke-test-checklist.md
+++ b/docs/avalonia-smoke-test-checklist.md
@@ -1,0 +1,64 @@
+# Avalonia GUI — Manual Smoke Test Checklist
+
+> **Purpose:** Verify the Avalonia GUI (`Dungnz.Display.Avalonia`) works correctly on a developer workstation.
+> This checklist is for **local manual testing** — the Avalonia app requires a desktop environment with a display server (X11 or Wayland) and cannot be verified in headless CI.
+
+## Prerequisites
+
+- .NET 10 SDK installed
+- Desktop environment with display server (X11/Wayland)
+- Repository cloned and dependencies restored (`dotnet restore`)
+
+## Launch Command
+
+```bash
+dotnet run --project Dungnz.Display.Avalonia
+```
+
+## Test Scenarios
+
+| # | Scenario | Steps | Expected Result | Pass? |
+|---|----------|-------|-----------------|-------|
+| 1 | Application launch | Run `dotnet run --project Dungnz.Display.Avalonia` | Window opens with title "Dungnz — Dungeon Crawler", 1200×800 default size, dark background (#1a1a1a), 6 panels visible | ☐ |
+| 2 | Map panel renders | Observe top-left panel after launch | ASCII dungeon map with room grid and connectors; default text "Map will appear here" replaced after game loop starts | ☐ |
+| 3 | Stats panel shows player info | Observe top-right panel after launch | Shows "Adventurer" (Warrior), HP bar 100/100 (green), Level 1, ATK/DEF stats, Gold 0 | ☐ |
+| 4 | Content panel shows room description | Observe middle-left panel after launch | Non-empty text describing the starting room; scrollable if content exceeds panel height | ☐ |
+| 5 | Gear panel shows equipment slots | Observe middle-right panel after launch | Equipment slot list with emoji icons (⚔ Weapon, 🦺 Chest, etc.); initially all "empty" or "—" | ☐ |
+| 6 | Log panel accumulates messages | Observe bottom-left panel after launch | At least 2–3 timestamped log entries (e.g., room entry, startup info); format `HH:mm ℹ message` | ☐ |
+| 7 | Input panel accepts typing | Click the input TextBox (bottom-right), type any text | Typed text appears in the input box; placeholder "Enter command..." disappears; prompt shows `> ` | ☐ |
+| 8 | Command submission | Type any valid command (e.g., "look") and press Enter | Command is submitted, input box clears, game responds in Content/Log panels | ☐ |
+| 9 | Movement command | Type `n` + Enter (or `s`, `e`, `w` if north unavailable) | Player moves to adjacent room; Map panel updates; Content panel shows new room description | ☐ |
+| 10 | Quit command | Type `quit` + Enter | Window closes cleanly; process exits with code 0 | ☐ |
+| 11 | Window close via X button | Click the window's X (close) button | Process exits cleanly with no hang or orphaned process | ☐ |
+| 12 | Window resize | Drag window edges to resize (smaller and larger) | Panels reflow proportionally; no crash, no rendering artifacts, no truncated text | ☐ |
+
+## Known Limitations
+
+- **Headless / CI environments:** The app exits with code 124 (timeout) or fails to open a window when no display server is available. This is expected — Avalonia requires a graphical environment.
+- **Input panel starts disabled:** The input TextBox is disabled until the game loop reaches its first `ReadLine()` call. There is a brief delay (~1–2 seconds) after window open before input becomes active.
+- **`ReadKey()` not implemented:** `AvaloniaInputReader.ReadKey()` returns `null`; the game falls back to numbered text prompts instead of arrow-key menus (planned for P6).
+- **`IsInteractive` returns `false`:** Interactive key-based navigation is not yet supported in the Avalonia frontend.
+
+## Hardcoded Values in `App.axaml.cs`
+
+The following values are hardcoded in `App.axaml.cs` and should be made configurable before shipping (tracked as `TODO(P3-P8)`):
+
+| Line | Value | Hardcoded To | Should Be |
+|------|-------|-------------|-----------|
+| 49 | Difficulty | `Difficulty.Normal` | Player-selectable (P3 startup flow) |
+| 59 | Dungeon seed | `12345` | Random or player-entered seed |
+| 62 | Player name | `"Adventurer"` | Player-entered name (P3 startup flow) |
+| 63 | Player class | `PlayerClass.Warrior` | Player-selectable (P3 class selection) |
+| 68 | Input reader | `AvaloniaInputReader` | Correct for Avalonia — no change needed |
+
+> **Note:** Lines 49–63 are intentional scaffolding for the P2 smoke test milestone. The full startup flow (name entry, class selection, difficulty picker) is planned for P3–P8 and is annotated with `TODO(P3-P8)` in the source.
+
+## Verification Attempt (Headless)
+
+**Date:** 2026-03-21
+**Environment:** Linux (Wayland session, `DISPLAY=:0`, `WAYLAND_DISPLAY=wayland-0`)
+
+- `dotnet build Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj` — ✅ 0 errors
+- `dotnet run --project Dungnz.Display.Avalonia` — App starts, log shows `"Dungnz Avalonia GUI starting..."`, process remains running (GUI window opens but headless session prevents interaction)
+- Process killed by `timeout 10` → exit code 124 (SIGTERM, not a crash)
+- **Conclusion:** App launches and initializes correctly. Full interactive verification requires a desktop session with keyboard/mouse access.


### PR DESCRIPTION
## WI-R09: Avalonia Smoke Test Checklist

Creates `docs/avalonia-smoke-test-checklist.md` — a 12-scenario manual smoke test checklist for the Avalonia GUI frontend.

### Changes
- **New:** `docs/avalonia-smoke-test-checklist.md` with 12 test scenarios covering app launch, all 6 panels, user input, commands, quit, window close, and resize
- **Audit:** Documented 4 hardcoded values in `App.axaml.cs` (difficulty, seed, player name, player class) — all intentional P2 scaffolding, tracked as `TODO(P3-P8)`
- **Verification:** App builds cleanly and launches in headless environment; interactive testing requires desktop session
- **Updated:** Hill history and decision inbox entry

### Hardcoded Values Found (App.axaml.cs)
| Line | Value | Hardcoded To |
|------|-------|-------------|
| 49 | Difficulty | `Difficulty.Normal` |
| 59 | Seed | `12345` |
| 62 | Player name | `"Adventurer"` |
| 63 | Player class | `PlayerClass.Warrior` |

All are P2 scaffolding; full startup flow planned for P3–P8.

Closes #1419