### PR TITLE
ci: Add explicit Avalonia build validation step (Regression Wave 3)

### DIFF
--- a/.ai-team/agents/fitz/history.md
+++ b/.ai-team/agents/fitz/history.md
@@ -362,3 +362,27 @@ Your smoke-test.yml addition has been recorded in decisions.md. This captures th
 - Contamination file conflicts were handled cleanly by always taking master's version (--theirs).
 - Pre-commit build verification caught all issues before merge completion.
 - Squash merges preserved all PR context while keeping master history clean.
+
+---
+
+### 2026-03-14 — Explicit Avalonia Build Validation in CI (#1424)
+
+**PR:** (pending) — `ci: Add explicit Avalonia build validation step (Regression Wave 3)`
+**Branch:** `squad/regression-wave3-fitz`
+**File Modified:** `.github/workflows/squad-ci.yml`
+
+**Problem:**
+- `Dungnz.Display.Avalonia` is included in the solution and gets built during the `dotnet build` step
+- However, Avalonia-specific failures (XAML compilation, NuGet package issues) are buried in solution-wide output
+- Avalonia is excluded from test coverage via `/p:Exclude=[Dungnz.Display.Avalonia]*`
+- Need a dedicated step so Avalonia build failures surface clearly in CI
+
+**Implementation:**
+- Added explicit `dotnet build Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj --configuration Release --no-restore` step
+- Placed after solution Build and before test step (step 6 of 14)
+- Added explanatory comment about why it's separate
+
+**Verification:**
+- ✅ Local build succeeds (Release configuration)
+- ✅ YAML syntax validated (14 steps, correct ordering)
+- ✅ Avalonia NuGet packages (Avalonia 11.3.12, CommunityToolkit.Mvvm 8.4.0) restore correctly

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
+      # Avalonia is excluded from coverage (GUI, untestable in headless CI) but must
+      # still compile.  Building it explicitly surfaces Avalonia-specific failures
+      # (XAML compilation, NuGet package issues) with a clear step name instead of
+      # burying them in the solution-wide build output.
+      - name: Build Avalonia project
+        run: dotnet build Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj --configuration Release --no-restore
+
       - name: Run tests with coverage
         # COVERAGE FLOOR: 80% total line coverage required (#878).
         # ThresholdStat=total checks aggregate coverage across all modules (not per-module minimum).


### PR DESCRIPTION
## Summary

Add a dedicated CI build step for **Dungnz.Display.Avalonia** so that Avalonia-specific compilation failures (XAML compilation, NuGet package resolution) surface with a clear step name instead of being buried in the solution-wide build output.

## Changes

- **`.github/workflows/squad-ci.yml`**: Added `Build Avalonia project` step (step 6 of 14) after solution build, before tests
- **`.ai-team/agents/fitz/history.md`**: Updated with WI-R08 entry

## Why

Avalonia is excluded from test coverage (`/p:Exclude=[Dungnz.Display.Avalonia]*`) since it's a GUI project untestable in headless CI. Without an explicit build step, Avalonia compilation errors only appear as noise in the full solution build — this step makes failures fast and obvious.

## Verification

- ✅ Local build passes (`dotnet build Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj --configuration Release`)
- ✅ YAML syntax validated (14 steps, correct ordering)
- ✅ Pre-commit build hook passed

Closes #1424