### PR TITLE
fix(avalonia): add ScrollViewer Name attributes for auto-scroll

### DIFF
--- a/Dungnz.Display.Avalonia/Views/Panels/ContentPanel.axaml
+++ b/Dungnz.Display.Avalonia/Views/Panels/ContentPanel.axaml
@@ -4,7 +4,7 @@
              xmlns:controls="using:Dungnz.Display.Avalonia.Controls"
              x:Class="Dungnz.Display.Avalonia.Views.Panels.ContentPanel"
              x:DataType="vm:ContentPanelViewModel">
-  <ScrollViewer>
+  <ScrollViewer Name="ContentScrollViewer">
     <ItemsControl ItemsSource="{Binding ContentLines}">
       <ItemsControl.ItemTemplate>
         <DataTemplate>

--- a/Dungnz.Display.Avalonia/Views/Panels/LogPanel.axaml
+++ b/Dungnz.Display.Avalonia/Views/Panels/LogPanel.axaml
@@ -4,7 +4,7 @@
              xmlns:controls="using:Dungnz.Display.Avalonia.Controls"
              x:Class="Dungnz.Display.Avalonia.Views.Panels.LogPanel"
              x:DataType="vm:LogPanelViewModel">
-  <ScrollViewer>
+  <ScrollViewer Name="LogScrollViewer">
     <ItemsControl ItemsSource="{Binding LogLines}">
       <ItemsControl.ItemTemplate>
         <DataTemplate>


### PR DESCRIPTION
The auto-scroll code-behind files reference ScrollViewers by name (ContentScrollViewer, LogScrollViewer) via FindControl, but the AXAML was missing the Name attributes. Auto-scroll silently failed.

Closes #1436