### PR TITLE
feat(avalonia): UI polish — palette, borders, shortcuts, ability labels

### DIFF
--- a/Dungnz.Display.Avalonia/App.axaml
+++ b/Dungnz.Display.Avalonia/App.axaml
@@ -5,4 +5,15 @@
   <Application.Styles>
     <FluentTheme />
   </Application.Styles>
+  <Application.Resources>
+    <SolidColorBrush x:Key="GameBackground" Color="#1a1a1a" />
+    <SolidColorBrush x:Key="PanelBorder" Color="#444444" />
+    <SolidColorBrush x:Key="MapBorder" Color="#334466" />
+    <SolidColorBrush x:Key="StatsBorder" Color="#336644" />
+    <SolidColorBrush x:Key="ContentBorder" Color="#555555" />
+    <SolidColorBrush x:Key="GearBorder" Color="#554433" />
+    <SolidColorBrush x:Key="LogBorder" Color="#3a3a3a" />
+    <SolidColorBrush x:Key="InputBorder" Color="#446688" />
+    <SolidColorBrush x:Key="InputActiveBorder" Color="#6688aa" />
+  </Application.Resources>
 </Application>

--- a/Dungnz.Display.Avalonia/AvaloniaDisplayService.cs
+++ b/Dungnz.Display.Avalonia/AvaloniaDisplayService.cs
@@ -276,8 +276,12 @@ public class AvaloniaDisplayService : IDisplayService
     /// <inheritdoc/>
     public void ShowColoredCombatMessage(string message, string color)
     {
-        // For plain text, ignore color
-        ShowCombatMessage(message);
+        var coloredMsg = $"{color}{StripAnsi(message)}{ColorCodes.Reset}";
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.AppendMessage($"  {coloredMsg}");
+            _vm.Log.AppendLog(coloredMsg, "combat");
+        });
     }
 
     /// <inheritdoc/>
@@ -649,8 +653,12 @@ public class AvaloniaDisplayService : IDisplayService
     /// <inheritdoc/>
     public void ShowColoredMessage(string message, string color)
     {
-        // For plain text, ignore color
-        ShowMessage(message);
+        var coloredMsg = $"{color}{StripAnsi(message)}{ColorCodes.Reset}";
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            _vm.Content.AppendMessage(coloredMsg);
+            _vm.Log.AppendLog(coloredMsg, "info");
+        });
     }
 
     /// <inheritdoc/>
@@ -658,7 +666,8 @@ public class AvaloniaDisplayService : IDisplayService
     {
         var cleanLabel = StripAnsi(label);
         var cleanValue = StripAnsi(value);
-        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage($"{cleanLabel,-8} {cleanValue}"));
+        var line = $"{cleanLabel,-8} {valueColor}{cleanValue}{ColorCodes.Reset}";
+        Dispatcher.UIThread.InvokeAsync(() => _vm.Content.AppendMessage(line));
     }
 
     /// <inheritdoc/>
@@ -1000,10 +1009,10 @@ public class AvaloniaDisplayService : IDisplayService
 
         var options = new (string Label, string Value)[]
         {
-            ("⚔  Attack",  "A"),
-            ("✨ Ability",  "B"),
-            ("🏃 Flee",     "F"),
-            ("🧪 Use Item", "I"),
+            ($"{ColorCodes.Yellow}[A]{ColorCodes.Reset} ⚔  Attack",  "A"),
+            ($"{ColorCodes.Yellow}[B]{ColorCodes.Reset} ✨ Ability",  "B"),
+            ($"{ColorCodes.Yellow}[F]{ColorCodes.Reset} 🏃 Flee",     "F"),
+            ($"{ColorCodes.Yellow}[I]{ColorCodes.Reset} 🧪 Use Item", "I"),
         };
 
         // Build combined menu text
@@ -1047,9 +1056,9 @@ public class AvaloniaDisplayService : IDisplayService
         foreach (var (ability, onCooldown, cooldownTurns, notEnoughMana) in unavailableAbilities)
         {
             if (onCooldown)
-                sb.AppendLine($"  ○ {ability.Name} — Cooldown: {cooldownTurns} turns (Cost: {ability.ManaCost} MP)");
+                sb.AppendLine($"  {ColorCodes.Gray}○ {ability.Name} — {ColorCodes.Yellow}[COOLDOWN: {cooldownTurns}t]{ColorCodes.Reset}");
             else if (notEnoughMana)
-                sb.AppendLine($"  ○ {ability.Name} — Need {ability.ManaCost} MP");
+                sb.AppendLine($"  {ColorCodes.Gray}○ {ability.Name} — {ColorCodes.BrightRed}[NEED {ability.ManaCost} MP]{ColorCodes.Reset}");
         }
 
         sb.AppendLine();

--- a/Dungnz.Display.Avalonia/Converters/TierColorConverter.cs
+++ b/Dungnz.Display.Avalonia/Converters/TierColorConverter.cs
@@ -1,20 +1,31 @@
 using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Dungnz.Models;
 using System.Globalization;
 
 namespace Dungnz.Display.Avalonia.Converters;
 
 /// <summary>
-/// Converts ItemTier to Color for item name rendering.
-/// TODO: P3-P8 implementation.
+/// Converts <see cref="ItemTier"/> values to Avalonia <see cref="ISolidColorBrush"/>
+/// for XAML data-binding scenarios (e.g. item name foreground color).
 /// </summary>
 public class TierColorConverter : IValueConverter
 {
+    /// <inheritdoc/>
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        // Stub for Phase 2
-        return null;
+        if (value is not ItemTier tier) return null;
+        return tier switch
+        {
+            ItemTier.Uncommon  => new SolidColorBrush(Color.Parse("#44FF44")),
+            ItemTier.Rare      => new SolidColorBrush(Color.Parse("#66FFFF")),
+            ItemTier.Epic      => new SolidColorBrush(Color.Parse("#DD44FF")),
+            ItemTier.Legendary => new SolidColorBrush(Color.Parse("#FFDD44")),
+            _                  => new SolidColorBrush(Color.Parse("#FFFFFF")),
+        };
     }
 
+    /// <inheritdoc/>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         throw new NotImplementedException();

--- a/Dungnz.Display.Avalonia/ViewModels/LogPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/LogPanelViewModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Dungnz.Systems;
 using System.Collections.ObjectModel;
 
 namespace Dungnz.Display.Avalonia.ViewModels;
@@ -16,28 +17,34 @@ public partial class LogPanelViewModel : ObservableObject
     private const int MaxDisplayedLog = 12;
 
     /// <summary>
-    /// Appends a log entry with timestamp and type classification.
+    /// Appends a log entry with timestamp, type icon, and ANSI color classification.
     /// </summary>
     public void AppendLog(string message, string type = "info")
     {
         var timestamp = DateTime.Now.ToString("HH:mm");
         string icon;
+        string color;
 
         if (type == "combat")
         {
             icon = ClassifyCombatLogIcon(message);
+            color = ClassifyCombatLogColor(message);
         }
         else
         {
-            icon = type switch
+            (icon, color) = type switch
             {
-                "error" => "❌",
-                "loot"  => "💰",
-                _       => "ℹ"
+                "error" => ("❌", ColorCodes.BrightRed),
+                "loot"  => ("💰", ColorCodes.Yellow),
+                _       => ("ℹ", "")
             };
         }
 
-        _logHistory.Add($"{timestamp} {icon} {message}");
+        var logLine = string.IsNullOrEmpty(color)
+            ? $"{timestamp} {icon} {message}"
+            : $"{timestamp} {icon} {color}{message}{ColorCodes.Reset}";
+
+        _logHistory.Add(logLine);
         if (_logHistory.Count > MaxLogHistory)
             _logHistory.RemoveAt(0);
 
@@ -59,4 +66,15 @@ public partial class LogPanelViewModel : ObservableObject
         message.Contains("Poison", StringComparison.OrdinalIgnoreCase) ? "☠" :
         message.Contains("Burn", StringComparison.OrdinalIgnoreCase) ? "🔥" :
         "⚔";
+
+    /// <summary>
+    /// Returns the ANSI color code appropriate for a combat log message based on
+    /// keyword classification (critical hits, healing, status effects).
+    /// </summary>
+    private static string ClassifyCombatLogColor(string message) =>
+        message.Contains("Critical", StringComparison.OrdinalIgnoreCase) ? ColorCodes.BrightRed :
+        message.Contains("Healed", StringComparison.OrdinalIgnoreCase) ? ColorCodes.Green :
+        message.Contains("Poison", StringComparison.OrdinalIgnoreCase) ? ColorCodes.Magenta :
+        message.Contains("Burn", StringComparison.OrdinalIgnoreCase) ? ColorCodes.Yellow :
+        ColorCodes.Red;
 }

--- a/Dungnz.Display.Avalonia/Views/MainWindow.axaml
+++ b/Dungnz.Display.Avalonia/Views/MainWindow.axaml
@@ -12,30 +12,30 @@
     
     <!-- Top Row: Map (60%) | Stats (40%) -->
     <Grid Grid.Row="0" ColumnDefinitions="0.6*,0.4*" Margin="5">
-      <Border Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="0,0,5,0">
+      <Border Grid.Column="0" BorderBrush="{StaticResource MapBorder}" BorderThickness="1" CornerRadius="3" Padding="5" Margin="0,0,5,0">
         <panels:MapPanel DataContext="{Binding Map}" />
       </Border>
-      <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="5,0,0,0">
+      <Border Grid.Column="1" BorderBrush="{StaticResource StatsBorder}" BorderThickness="1" CornerRadius="3" Padding="5" Margin="5,0,0,0">
         <panels:StatsPanel DataContext="{Binding Stats}" />
       </Border>
     </Grid>
 
     <!-- Middle Row: Content (70%) | Gear (30%) -->
     <Grid Grid.Row="1" ColumnDefinitions="0.7*,0.3*" Margin="5">
-      <Border Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="0,0,5,0">
+      <Border Grid.Column="0" BorderBrush="{StaticResource ContentBorder}" BorderThickness="1" CornerRadius="3" Padding="5" Margin="0,0,5,0">
         <panels:ContentPanel DataContext="{Binding Content}" />
       </Border>
-      <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="5,0,0,0">
+      <Border Grid.Column="1" BorderBrush="{StaticResource GearBorder}" BorderThickness="1" CornerRadius="3" Padding="5" Margin="5,0,0,0">
         <panels:GearPanel DataContext="{Binding Gear}" />
       </Border>
     </Grid>
 
     <!-- Bottom Row: Log (70%) | Input (30%) -->
     <Grid Grid.Row="2" ColumnDefinitions="0.7*,0.3*" Margin="5">
-      <Border Grid.Column="0" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="0,0,5,0">
+      <Border Grid.Column="0" BorderBrush="{StaticResource LogBorder}" BorderThickness="1" CornerRadius="3" Padding="5" Margin="0,0,5,0">
         <panels:LogPanel DataContext="{Binding Log}" />
       </Border>
-      <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="5,0,0,0">
+      <Border Grid.Column="1" BorderBrush="{StaticResource InputBorder}" BorderThickness="1" CornerRadius="3" Padding="5" Margin="5,0,0,0">
         <panels:InputPanel DataContext="{Binding Input}" />
       </Border>
     </Grid>

--- a/Dungnz.Display.Avalonia/Views/Panels/ContentPanel.axaml
+++ b/Dungnz.Display.Avalonia/Views/Panels/ContentPanel.axaml
@@ -4,13 +4,21 @@
              xmlns:controls="using:Dungnz.Display.Avalonia.Controls"
              x:Class="Dungnz.Display.Avalonia.Views.Panels.ContentPanel"
              x:DataType="vm:ContentPanelViewModel">
-  <ScrollViewer Name="ContentScrollViewer">
-    <ItemsControl ItemsSource="{Binding ContentLines}">
-      <ItemsControl.ItemTemplate>
-        <DataTemplate>
-          <controls:AnsiTextBlock FormattedText="{Binding}" FontFamily="Consolas,Courier New,monospace" />
-        </DataTemplate>
-      </ItemsControl.ItemTemplate>
-    </ItemsControl>
-  </ScrollViewer>
+  <DockPanel>
+    <controls:AnsiTextBlock DockPanel.Dock="Top"
+                            FormattedText="{Binding HeaderText}"
+                            FontFamily="Consolas,Courier New,monospace"
+                            FontWeight="Bold"
+                            FontSize="14"
+                            Margin="4,2,4,4" />
+    <ScrollViewer Name="ContentScrollViewer" Padding="4,2">
+      <ItemsControl ItemsSource="{Binding ContentLines}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <controls:AnsiTextBlock FormattedText="{Binding}" FontFamily="Consolas,Courier New,monospace" />
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </ScrollViewer>
+  </DockPanel>
 </UserControl>

--- a/Dungnz.Display.Avalonia/Views/Panels/InputPanel.axaml.cs
+++ b/Dungnz.Display.Avalonia/Views/Panels/InputPanel.axaml.cs
@@ -21,10 +21,15 @@ public partial class InputPanel : UserControl
         CommandInput.AddHandler(KeyDownEvent, OnCommandInputKeyDown, RoutingStrategies.Tunnel);
 
         // Auto-focus the TextBox whenever IsEnabled flips to true
+        // and dim/restore opacity to give visual feedback
         CommandInput.PropertyChanged += (_, e) =>
         {
-            if (e.Property == IsEnabledProperty && e.NewValue is true)
-                CommandInput.Focus();
+            if (e.Property == IsEnabledProperty)
+            {
+                CommandInput.Opacity = e.NewValue is true ? 1.0 : 0.5;
+                if (e.NewValue is true)
+                    CommandInput.Focus();
+            }
         };
     }
 


### PR DESCRIPTION
## Summary

Visual polish pass for the Avalonia GUI — game-specific color palette, improved panel borders, combat shortcut visibility, ability status labels, and input focus feedback.

### Changes

#### 1. Game Color Palette (`App.axaml`)
Added `Application.Resources` with named `SolidColorBrush` entries for all panel border colors: `MapBorder`, `StatsBorder`, `ContentBorder`, `GearBorder`, `LogBorder`, `InputBorder`, `InputActiveBorder`, and `GameBackground`.

#### 2. Panel Border Improvements (`MainWindow.axaml`)
Replaced all `BorderBrush="Gray"` with palette references (`{StaticResource MapBorder}`, etc.) and added `CornerRadius="3"` to every panel border for softer edges.

#### 3. Content Panel Header + Padding (`ContentPanel.axaml`)
- Wrapped content in a `DockPanel` with an `AnsiTextBlock` header bound to `HeaderText` (bold, 14pt, docked top).
- Added `Padding="4,2"` to the `ScrollViewer` for breathing room.

#### 4. Combat Menu Shortcut Visibility (`AvaloniaDisplayService.cs`)
Prefixed combat menu options with ANSI-yellow shortcut keys: `[A] ⚔  Attack`, `[B] ✨ Ability`, `[F] 🏃 Flee`, `[I] 🧪 Use Item`.

#### 5. Unavailable Ability Labels (`AvaloniaDisplayService.cs`)
Changed unavailable ability display from plain text to colored labels:
- Cooldown: `○ Name — [COOLDOWN: Nt]` (yellow)
- Insufficient mana: `○ Name — [NEED N MP]` (bright red)

#### 6. Input Panel Focus Feedback (`InputPanel.axaml.cs`)
TextBox opacity dims to 0.5 when input is disabled, restores to 1.0 when enabled — gives clear visual feedback for input availability.

#### 7. TierColorConverter Implementation (`TierColorConverter.cs`)
Replaced stub with real `ItemTier → SolidColorBrush` mapping (Uncommon→green, Rare→cyan, Epic→magenta, Legendary→yellow, Common→white).

#### 8. Log Panel ANSI Coloring (`LogPanelViewModel.cs`)
Added ANSI color codes to log entries by type: red for errors, yellow for loot, combat-classified colors for combat messages.

### Verification
- `dotnet build Dungnz.Display.Avalonia/Dungnz.Display.Avalonia.csproj` — ✅ 0 errors
- `dotnet test Dungnz.Tests/Dungnz.Tests.csproj` — ✅ 2351 passed, 0 failed
- Only `Display/` layer touched — no README update required (no documented systems changed)

Closes #1438