### PR TITLE
feat(avalonia): add ANSI color codes to Stats, Gear, and Map panel ViewModels

### DIFF
--- a/Dungnz.Display.Avalonia/ViewModels/GearPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/GearPanelViewModel.cs
@@ -37,7 +37,7 @@ public partial class GearPanelViewModel : ObservableObject
         {
             if (item == null)
             {
-                sb.AppendLine($"{slotLabel}:  (empty)");
+                sb.AppendLine($"{slotLabel}:  {ColorCodes.Gray}(empty){ColorCodes.Reset}");
                 return;
             }
             var statParts = new List<string>();
@@ -61,7 +61,8 @@ public partial class GearPanelViewModel : ObservableObject
                 if (item.MaxManaBonus >  0) statParts.Add($"+{item.MaxManaBonus} mana");
             }
             var statsStr = statParts.Count > 0 ? "  " + string.Join(", ", statParts) : "";
-            sb.AppendLine($"{slotLabel}:  {item.Name}{statsStr}");
+            var coloredName = ColorCodes.ColorizeItemName(item.Name, item.Tier);
+            sb.AppendLine($"{slotLabel}:  {coloredName}{statsStr}");
         }
 
         AddSlot("⚔  Weapon",    player.EquippedWeapon,    isWeapon: true);
@@ -89,19 +90,20 @@ public partial class GearPanelViewModel : ObservableObject
     {
         var sb = new StringBuilder();
 
-        sb.AppendLine($"🐉 {enemy.Name}");
+        sb.AppendLine($"🐉 {ColorCodes.BrightRed}{enemy.Name}{ColorCodes.Reset}");
 
         if (enemy is Dungnz.Systems.Enemies.DungeonBoss boss)
         {
             var phaseNum = boss.FiredPhases.Count + 1;
             sb.Append($"Phase {phaseNum}");
             if (boss.IsEnraged)
-                sb.Append($"  ⚡ ENRAGED");
+                sb.Append($"  {ColorCodes.BrightRed}⚡ ENRAGED{ColorCodes.Reset}");
             sb.AppendLine();
         }
 
+        var hpColor = ColorCodes.HealthColor(enemy.HP, enemy.MaxHP);
         var hpBar = BuildPlainHpBar(enemy.HP, enemy.MaxHP);
-        sb.AppendLine($"HP {hpBar} {enemy.HP}/{enemy.MaxHP}");
+        sb.AppendLine($"HP {hpColor}{hpBar} {enemy.HP}/{enemy.MaxHP}{ColorCodes.Reset}");
         sb.AppendLine($"ATK {enemy.Attack}  DEF {enemy.Defense}");
 
         var regenParts = new List<string>();

--- a/Dungnz.Display.Avalonia/ViewModels/MapPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/MapPanelViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Dungnz.Display;
 using Dungnz.Models;
+using Dungnz.Systems;
 
 namespace Dungnz.Display.Avalonia.ViewModels;
 
@@ -21,6 +22,18 @@ public partial class MapPanelViewModel : ObservableObject
     public void Update(Room currentRoom, int floor)
     {
         CurrentFloor = floor;
-        MapText = MapRenderer.BuildPlainTextMap(currentRoom, floor);
+        var plainMap = MapRenderer.BuildPlainTextMap(currentRoom, floor);
+        MapText = ColorizeMap(plainMap);
+    }
+
+    /// <summary>
+    /// Applies ANSI color codes to map markers for rendering in AnsiTextBlock.
+    /// </summary>
+    private static string ColorizeMap(string plainMap)
+    {
+        var result = plainMap.Replace("[X]", $"{ColorCodes.BrightWhite}[X]{ColorCodes.Reset}");
+        result = result.Replace("[?]", $"{ColorCodes.Gray}[?]{ColorCodes.Reset}");
+        result = result.Replace("[E]", $"{ColorCodes.Green}[E]{ColorCodes.Reset}");
+        return result;
     }
 }

--- a/Dungnz.Display.Avalonia/ViewModels/StatsPanelViewModel.cs
+++ b/Dungnz.Display.Avalonia/ViewModels/StatsPanelViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Dungnz.Models;
+using Dungnz.Systems;
 using System.Text;
 
 namespace Dungnz.Display.Avalonia.ViewModels;
@@ -32,16 +33,18 @@ public partial class StatsPanelViewModel : ObservableObject
     private static string BuildPlayerStatsText(Player player, IReadOnlyList<(string name, int turnsRemaining)> cooldowns)
     {
         var sb = new StringBuilder();
-        sb.AppendLine($"{player.Name}  Lv {player.Level}  {player.Class}");
+        sb.AppendLine($"{ColorCodes.BrightWhite}{player.Name}{ColorCodes.Reset}  {ColorCodes.Yellow}Lv {player.Level}{ColorCodes.Reset}  {player.Class}");
         sb.AppendLine();
 
+        var hpColor = ColorCodes.HealthColor(player.HP, player.MaxHP);
         var hpBar = BuildPlainHpBar(player.HP, player.MaxHP);
-        sb.AppendLine($"HP {hpBar} {player.HP}/{player.MaxHP}");
+        sb.AppendLine($"HP {hpColor}{hpBar} {player.HP}/{player.MaxHP}{ColorCodes.Reset}");
 
         if (player.MaxMana > 0)
         {
+            var mpColor = ColorCodes.ManaColor(player.Mana, player.MaxMana);
             var mpBar = BuildPlainMpBar(player.Mana, player.MaxMana);
-            sb.AppendLine($"MP {mpBar} {player.Mana}/{player.MaxMana}");
+            sb.AppendLine($"MP {mpColor}{mpBar} {player.Mana}/{player.MaxMana}{ColorCodes.Reset}");
         }
 
         if (cooldowns.Count > 0)
@@ -76,7 +79,7 @@ public partial class StatsPanelViewModel : ObservableObject
                 _                   => "Momentum"
             };
             var dots = new string('●', momentum.Current) + new string('○', momentum.Maximum - momentum.Current);
-            var chargedSuffix = momentum.IsCharged ? " [CHARGED]" : string.Empty;
+            var chargedSuffix = momentum.IsCharged ? $" {ColorCodes.Yellow}[CHARGED]{ColorCodes.Reset}" : string.Empty;
             sb.AppendLine($"❖ {label} {dots}{chargedSuffix}");
         }
 


### PR DESCRIPTION
## Summary

Adds ANSI color support to the three remaining Avalonia panel ViewModels that were still rendering plain text. Now that `AnsiTextBlock` parses ANSI escape codes, these ViewModels embed color codes via `ColorCodes` helpers so the UI renders with proper color.

### Changes

#### StatsPanelViewModel
- HP bar colored by health threshold (`ColorCodes.HealthColor`): green > 70%, yellow > 40%, red > 20%, bright red below
- MP bar colored by mana level (`ColorCodes.ManaColor`): blue > 50%, cyan > 20%, gray below
- Player name in bright white, level in yellow
- `[CHARGED]` momentum suffix highlighted in yellow

#### GearPanelViewModel
- Equipped item names colored by `ItemTier` via `ColorCodes.ColorizeItemName` (Common→white, Uncommon→green, Rare→bright cyan, Epic→magenta, Legendary→yellow)
- Empty slots shown in gray
- Enemy name in bright red, HP bar by health threshold
- ENRAGED badge in bright red

#### MapPanelViewModel
- Current room marker `[X]` in bright white
- Unexplored rooms `[?]` in gray
- Exit rooms `[E]` in green
- New `ColorizeMap()` helper applies ANSI codes to the plain text map

### Testing
- All 2351 tests pass (0 failures, 4 pre-existing skips)
- Build succeeds with 0 errors

Closes #1437